### PR TITLE
Added render view to mission table

### DIFF
--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -18,6 +18,7 @@ import {
 } from "@tabler/icons-react";
 import classes from "./Overview.module.css";
 import data from "./RandomData";
+import RenderView from "./RenderView";
 
 export interface RowData {
   name: string;
@@ -104,6 +105,8 @@ export function Overview() {
   const [sortedData, setSortedData] = useState(data);
   const [sortBy, setSortBy] = useState<keyof RowData | null>(null);
   const [reverseSortDirection, setReverseSortDirection] = useState(false);
+  const [modalOpened, setModalOpened] = useState(false);
+  const [selectedRow, setSelectedRow] = useState<RowData | null>(null);
 
   const setSorting = (field: keyof RowData) => {
     const reversed = field === sortBy ? !reverseSortDirection : false;
@@ -120,9 +123,15 @@ export function Overview() {
     );
   };
 
+  const openModal = (row: RowData) => {
+    setSelectedRow(row);
+    setModalOpened(true);
+  };
+
   const rows = sortedData.map((row) => (
     <Table.Tr
       key={row.name}
+      onClick={() => openModal(row)}
       style={{
         cursor: "pointer",
         transition: "background-color 0.2s ease",
@@ -196,6 +205,13 @@ export function Overview() {
           )}
         </Table.Tbody>
       </Table>
+
+      {/* Modal Component */}
+      <RenderView
+        modalOpened={modalOpened}
+        selectedRow={selectedRow}
+        onClose={() => setModalOpened(false)}
+      />
     </ScrollArea>
   );
 }

--- a/frontend/app/pages/missions/RenderView.tsx
+++ b/frontend/app/pages/missions/RenderView.tsx
@@ -1,0 +1,54 @@
+import { Modal, Text } from "@mantine/core";
+import React from "react";
+import { RowData } from "./Overview";
+
+interface RenderViewProps {
+  modalOpened: boolean;
+  selectedRow: RowData | null;
+  onClose: () => void;
+}
+
+const RenderView: React.FC<RenderViewProps> = ({
+  modalOpened,
+  selectedRow,
+  onClose,
+}) => {
+  return (
+    <Modal
+      opened={modalOpened}
+      onClose={onClose}
+      title={
+        selectedRow ? `Details for ${selectedRow.name}` : "Mission Details"
+      }
+      size="100%"
+      styles={{
+        content: {
+          borderRadius: "20px",
+          height: "90vh",
+        },
+      }}
+    >
+      {selectedRow && (
+        <div>
+          <Text>
+            <strong>Location:</strong> {selectedRow.location}
+          </Text>
+          <Text>
+            <strong>Duration:</strong> {selectedRow.duration}
+          </Text>
+          <Text>
+            <strong>Size:</strong> {selectedRow.size}
+          </Text>
+          <Text>
+            <strong>Robot:</strong> {selectedRow.robot}
+          </Text>
+          <Text>
+            <strong>Other:</strong> {selectedRow.other}
+          </Text>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default RenderView;


### PR DESCRIPTION
Hi, this PR adds a render view to the mission table. To open it, click on a row:
![image](https://github.com/user-attachments/assets/24603fa8-5eb5-4712-ba75-96a92b8c9265)

In here, more details of the selected mission can be shown. In the future, this view can be organized with grids from mantine, see:
https://ui.mantine.dev/category/grids/

See readme.md with installation instructions.

Issue #8 