### PR TITLE
Adds ruff cache files to git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ db.sqlite3
 *.env
 .vscode
 
-.ruff_cache/
+**/.ruff_cache/


### PR DESCRIPTION
Ruff creates a cache file in the local working directory, this should not be committed.
This PR addresses this by changing the .gitignore file.

https://docs.astral.sh/ruff/settings/#cache-dir

As an alternative, one can change the cache directory. 

