### PR TITLE
correct the naming of the tab when in missions or settings page

### DIFF
--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -3,10 +3,7 @@ import { CreateAppShell } from "~/layout/AppShell";
 import MissionsPage from "~/pages/missions/MissionsPage";
 
 export const meta: MetaFunction = () => {
-  return [
-    { title: "Mission overview" },
-    { name: "description", content: "Mission overview" },
-  ];
+  return [{ title: "Missions" }];
 };
 
 export default function Index() {

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -2,10 +2,7 @@ import type { MetaFunction } from "@remix-run/node";
 import { CreateAppShell } from "~/layout/AppShell";
 import SettingsPage from "~/pages/SettingsPage";
 export const meta: MetaFunction = () => {
-  return [
-    { title: "Missions" },
-    { name: "description", content: "Mission overview" },
-  ];
+  return [{ title: "Settings" }];
 };
 
 export default function Index() {


### PR DESCRIPTION
# Changes
I Changed the Title of the settings page and the missions page so that they show correctly in the tab. Like so: 
![grafik](https://github.com/user-attachments/assets/889e1fee-7841-4aa5-867a-813aa9a0ffb4)
Before that it showed "Missions" when in Settings