### PR TITLE
Moved frontend documentation and added production server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,1 @@
 # polybot_mission_db
-
-## Frontend Setup
-1. **Install Node.js (if needed)**
-   - If `npm` is not available on your system, [download and install Node.js](https://nodejs.org/). This will include `npm`.
-
-2. **Install Project Dependencies**
-   - Once Node.js is installed, navigate to the frontend directory and run:
-     ```bash
-     npm install
-     ```
-   - This command will download and set up all necessary dependencies for the project.
-
-2. **Start the Web Server**
-   - Start the web server by typing:
-     ```bash
-     npm run dev
-     ```
-    

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+## Frontend Setup
+1. **Install Node.js (if needed)**
+   - If `npm` is not available on your system, [download and install Node.js](https://nodejs.org/). This will include `npm`.
+
+2. **Install Project Dependencies**
+   - Once Node.js is installed, navigate to the frontend directory and run:
+     ```bash
+     npm install
+     ```
+   - This command will download and set up all necessary dependencies for the project.
+
+2. **Start the Web Server**
+   - For development, it is recommended to use the dev server, start it by typing:
+     ```bash
+     npm run dev
+     ```
+     It offers additional features like debugging or hot reload, but this leads to higher loading times. Alternatively, use the production server. Build the project: 
+     ```bash 
+     npm run build
+     ```
+     Start the production server:
+     ```bash 
+     npm start
+     ```
+
+
+


### PR DESCRIPTION
Hi,
i found out that the long loading times in the frontend originate from the dev environment (i. e.: `npm run dev`), but this enables features like debugging and hot reload. When switching to production, the page loads instantly. 

To test it, type:
`npm run build`
and
`npm start`
in the frontend folder. Click on the URL.

This "resolves" issue #43 by extending (and moving) the frontend documentation. 