### PR TITLE
Added basic dataset view

### DIFF
--- a/frontend/app/pages/dataset/DatasetView.tsx
+++ b/frontend/app/pages/dataset/DatasetView.tsx
@@ -1,5 +1,6 @@
 import { Modal, Text } from "@mantine/core";
 
+// Interface describing expected properties of DatasetView
 interface DatasetViewProps {
   opened: boolean;
   onClose: () => void;
@@ -15,6 +16,7 @@ export function DatasetView({
   duration,
   size,
 }: DatasetViewProps) {
+  //Create a modal view for the dataset
   return (
     <Modal
       opened={opened}

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -14,10 +14,12 @@ export function ShowDatasets({ data }: { data: DetailViewData }) {
     setOpened(true);
   };
 
+  // Creates rows of table
   const rows = data.files.map((file, index) => (
     <Table.Tr
       key={file}
       onClick={() => handleRowClick(file, index)}
+      // Change color on mouse hover
       style={{
         cursor: "pointer",
         transition: "background-color 0.2s ease",
@@ -25,12 +27,14 @@ export function ShowDatasets({ data }: { data: DetailViewData }) {
       onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#f1f3f5")}
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "")}
     >
+      {/* Inserts data from DetailViewData, see data.tsx */}
       <Table.Td>{file}</Table.Td>
       <Table.Td>{data.durations[index]}</Table.Td>
       <Table.Td>{data.sizes[index]}</Table.Td>
     </Table.Tr>
   ));
 
+  // Returns the filled table with DatasetView, which is opend on state change
   return (
     <>
       <Table>


### PR DESCRIPTION
Hi, this PR is an extension of the detail view. It addresses issue #26 task "Make table entries clickable".

Also added a color effect when sliding with the mouse over the table. 
![image](https://github.com/user-attachments/assets/46cb66fa-46ae-4335-a6d3-bf255a0b5c28)

By clicking on a row, a new view opens, the so called "DatasetView". This will display more details about a dataset in future PRs.
![image](https://github.com/user-attachments/assets/eb551fcf-7a37-4930-9578-6eb1d78be6db)

