### PR TITLE
Fix CORS fetching error in production mode

### DIFF
--- a/missionlister/missionlister/settings.py
+++ b/missionlister/missionlister/settings.py
@@ -59,11 +59,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-    "http://192.168.0.40:3000", # URL of Production Server
-]
+CORS_ORIGIN_ALLOW_ALL = True
 
 CORS_ALLOW_CREDENTIALS = True
 


### PR DESCRIPTION
I added the URL of the production server to CORS_ALLOWED_ORIGINS to allow the production server to fetch the data from the backend.

You can try by setting USE_RANDOM_DATA to false and just running the production server and the backend as described in [frontend documentation](docs/frontend/README.md), [database documentation](docs/database/README.md) and [backend documentation](docs/restapi/README.md)

Resolves #71 