### PR TITLE
Fix cli.py imports

### DIFF
--- a/missionlister/cli.py
+++ b/missionlister/cli.py
@@ -3,13 +3,15 @@ import argparse
 import django
 import logging
 from datetime import datetime
-from restapi.models import Mission  # Importing Models, adjust as needed
 
 # Set up Django env
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE", "missionlister.settings"
 )  # Adjust as needed
 django.setup()
+
+# Importing Models, adjust as needed
+from restapi.models import Mission  # noqa
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
For the CLI to work the django setup needs to happen before the models are imported.\
I moved the imports to after the setup and added a special comment so ruff ignores that the import is not at the top of the file.\
You can check by running
```bash
python3 cli.py
```
It should display information about the usage of the CLI and no errors.