### PR TITLE
Adds a simple login ui

### DIFF
--- a/frontend/app/pages/login/LoginPage.module.css
+++ b/frontend/app/pages/login/LoginPage.module.css
@@ -1,0 +1,6 @@
+.title {
+    font-family:
+      Greycliff CF,
+      var(--mantine-font-family);
+    font-weight: 700;
+  }

--- a/frontend/app/pages/login/LoginPage.tsx
+++ b/frontend/app/pages/login/LoginPage.tsx
@@ -1,0 +1,34 @@
+import {
+  Button,
+  Checkbox,
+  Container,
+  Paper,
+  PasswordInput,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import classes from "./LoginPage.module.css";
+
+export function LoginView() {
+  return (
+    <Container size={420} my={40}>
+      <Title ta="center" className={classes.title}>
+        Login
+      </Title>
+
+      <Paper withBorder shadow="md" p={30} mt={30} radius="md">
+        <TextInput label="Username" placeholder="robot enjoyer" required />
+        <PasswordInput
+          label="Password"
+          placeholder="i like robots"
+          required
+          mt="md"
+        />
+        <Checkbox label="Remember me" mt="lg" />
+        <Button fullWidth mt="xl">
+          Sign in
+        </Button>
+      </Paper>
+    </Container>
+  );
+}

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -1,0 +1,10 @@
+import type { MetaFunction } from "@remix-run/node";
+import { LoginView } from "~/pages/login/LoginPage";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Login" }];
+};
+
+export default function Index() {
+  return <LoginView></LoginView>;
+}


### PR DESCRIPTION
This PR adds a simple login ui,
to see it, go to 
/login

![image](https://github.com/user-attachments/assets/421e77bc-f516-4120-8a11-fba8075453c7)

Code is based on a template from here:
https://ui.mantine.dev/category/authentication/#authentication-title

No worries, it is under a open source license :)
This resolves task 1 from issue #103 