### PR TITLE
tag picker beauty changes and error messages

### DIFF
--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -60,12 +60,12 @@ export const TagPicker: React.FC<TagPickerProps> = ({
 
   return (
     <Stack gap={4}>
-      <Group gap="xs" style={{ display: "flex" }}>
+      <Group gap="xs" style={{ display: "flex", marginBottom: "2px" }}>
         {/*input for new tag name*/}
         <TextInput
           value={newTagName}
           onChange={(e) => setNewTagName(e.target.value)}
-          placeholder="add a new tag"
+          placeholder="Add a new tag"
           error={error}
           onKeyDown={(e) => {
             e.key === "Enter" && handleAddTag();
@@ -75,10 +75,10 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         {/*button to add tag*/}
         <Button
           onClick={handleAddTag}
-          color="#dcdfe1"
           style={{ flex: 0.11, alignSelf: "flex-start" }}
+          disabled={!newTagName}
         >
-          <IconPlus size={16} color="grey" />
+          <IconPlus size={16} />
         </Button>
       </Group>
       {/*custom color picker*/}


### PR DESCRIPTION
resolves #117 

# Changes
- The Input field gets cleared after adding a Tag by pressing enter or the plus button
- I moved the "add tag" button to save some space and changed its color
- An Error message exists now for "this tag already exists" and "this tag name is too long" (if the tag has more then 42 characters) 
![grafik](https://github.com/user-attachments/assets/c72d5e10-7680-4af9-927b-af766b72f7d9)
![grafik](https://github.com/user-attachments/assets/572eab9e-3421-424f-b1e0-9f6e08ab6ed1)