### PR TITLE
Add permission denied handling for cli history file

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -483,16 +483,8 @@ class Interactive(code.InteractiveConsole):
 
 
 def interactive(parser: argparse.ArgumentParser):
-    not_created = False
     if readline:
-        if not os.path.exists(REPL_HISTFILE):
-            try:
-                open(REPL_HISTFILE, "a").close()
-            except PermissionError as p:
-                print(p, "\nCould not create history file")
-                not_created = True
-
-        if not not_created:
+        if os.path.exists(REPL_HISTFILE):
             try:
                 readline.read_history_file(REPL_HISTFILE)
             except PermissionError as p:
@@ -511,7 +503,7 @@ def interactive(parser: argparse.ArgumentParser):
     except SystemExit:
         pass
 
-    if readline and not not_created:
+    if readline:
         readline.set_history_length(REPL_HISTFILE_SIZE)
         try:
             readline.write_history_file(REPL_HISTFILE)

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -483,21 +483,20 @@ class Interactive(code.InteractiveConsole):
 
 
 def interactive(parser: argparse.ArgumentParser):
-    no_permission = False
+    not_created = False
     if readline:
         if not os.path.exists(REPL_HISTFILE):
             try:
                 open(REPL_HISTFILE, "a").close()
             except PermissionError as p:
                 print(p, "\nCould not create history file")
-                no_permission = True
+                not_created = True
 
-        if not no_permission:
+        if not not_created:
             try:
                 readline.read_history_file(REPL_HISTFILE)
             except PermissionError as p:
                 print(p, REPL_HISTFILE, "\nCould not read history file")
-                no_permission = True
 
         readline.set_completer_delims("")
         readline.set_completer(argcomplete.CompletionFinder(parser).rl_complete)
@@ -512,7 +511,7 @@ def interactive(parser: argparse.ArgumentParser):
     except SystemExit:
         pass
 
-    if readline and not no_permission:
+    if readline and not not_created:
         readline.set_history_length(REPL_HISTFILE_SIZE)
         try:
             readline.write_history_file(REPL_HISTFILE)

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -242,7 +242,7 @@ def remove_tag(id=None, name=None):
         missions_with_tag = Mission.objects.filter(mission_tags__tag=tag)
         if missions_with_tag.exists():
             response = input(
-                f"The Tag is used in {len(missions_with_tag)} Mission(s).\nDo you really want to remove it? [Y/n] "
+                f"The Tag is used in {len(missions_with_tag)} Mission(s).\nDo you really want to remove it? [y/N] "
             ).lower()
             if response == "y":
                 tag.delete()


### PR DESCRIPTION
The interactive mode uses a file to store the history across sessions, but when the user has no permissions for this file the whole interactive mode wouldn't work.\
I added handling of those PermissionErrors and now the interactive mode will work without those permissions, but the history can't be stored for the next time the script is executed.

There are 2 types of Permission Errors:
1. Writing/Creating the history file requires write permission on the directory of the file (users home directory)
2. Reading the history requires read permission

At least under Linux this is the case, but under Windows it should also work.

I also changed the display of default values when removing a tag that is used and it asks for verification:
[Y/n]  would suggest yes is the default but it is no so [y/N] is correct.

## How to test:
You need to change your permissions on your home directory to test this which can be dangerous, so don't forget to revert all permission changes.

Under linux you can do this:

Remove the file and write permisison on your home directory
```bash
rm ~/.polybot_mission_db_cli.py_hist
chmod u-w ~
```
Try `./cli.py`  and see an error only when exiting the interactive mode.
Give yourself write permission again create the file, but remove read permissions:
```bash
chmod u+w ~
touch ~/.polybot_mission_db_cli.py_hist
chmod 000 ~/.polybot_mission_db_cli.py_hist
```
and try `./cli.py` again, it should be a different error, but still work.

To make sure you have write permissions on your home directory again run
```bash
chmod u+w ~
```
or optionally with sudo