### PR TITLE
update frontend packages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1526,11 +1526,10 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.15.0.tgz",
-      "integrity": "sha512-iXV6u9PBwFc7KriDpVcjqLGJzZZd6ZOrxewen7hoH0OBzGwjkhtm46BTQEJrZ/e/dzlU1IU/0ylH29tN9BZoyg==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.15.1.tgz",
+      "integrity": "sha512-vuAVNCW0TsjdoLrpXRFTDJzWut+cfOYw6HVrwdin3J/isfZ2ZyRUNo4kdK4TkmEXoRtTWLk1MG6LbeTAJlg11g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.8",
         "@babel/generator": "^7.21.5",
@@ -1542,9 +1541,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.15.0",
+        "@remix-run/node": "2.15.1",
         "@remix-run/router": "1.21.0",
-        "@remix-run/server-runtime": "2.15.0",
+        "@remix-run/server-runtime": "2.15.1",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -1595,8 +1594,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/react": "^2.15.0",
-        "@remix-run/serve": "^2.15.0",
+        "@remix-run/react": "^2.15.1",
+        "@remix-run/serve": "^2.15.1",
         "typescript": "^5.1.0",
         "vite": "^5.1.0",
         "wrangler": "^3.28.2"
@@ -1617,12 +1616,11 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.15.0.tgz",
-      "integrity": "sha512-MyCXVmbrxeo06zJECuaOUQ01x13zEkmMUkFzaHESWMBxnTPGbtKF4Gb0iF6TrMFiSeaKptUU4JBvLeHooPOryA==",
-      "license": "MIT",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.15.1.tgz",
+      "integrity": "sha512-aw7aEj6K9HGjJqHB9JKHLp6WE/bisYmnt52pRzkK/nzCWgK3hwBdi7tj5KYFTw9WfgZhEQICUmA/pmuafo7wyg==",
       "dependencies": {
-        "@remix-run/node": "2.15.0"
+        "@remix-run/node": "2.15.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1638,12 +1636,11 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.15.0.tgz",
-      "integrity": "sha512-tWbR7pQ6gwj+MkGf6WVIYnjgfGfpdU8EOIa6xsCIRlrm0p3BtMz4jA3GvBWEpOuEnN5MV7CarVzhduaRzkZ0SQ==",
-      "license": "MIT",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.15.1.tgz",
+      "integrity": "sha512-23xWN3/yOohNUr27KS7hEcDMbtufMkniXfXkcLx8Dz2wUVNfJYGpICjeV48Ue/INtpiUCCzOYwkL9VRjIMEJbA==",
       "dependencies": {
-        "@remix-run/server-runtime": "2.15.0",
+        "@remix-run/server-runtime": "2.15.1",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -1664,13 +1661,12 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.15.0.tgz",
-      "integrity": "sha512-puqDbi9N/WfaUhzDnw2pACXtCB7ukrtFJ9ILwpEuhlaTBpjefifJ89igokW+tt1ePphIFMivAm/YspcbZdCQsA==",
-      "license": "MIT",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.15.1.tgz",
+      "integrity": "sha512-h0BVUeg87vt3FKbYfoF7Ln56MM3O8rvGLDKYOuPY0OgNlJVaQKQzWVX+mnlmzysX4hF7WnOPMw1q38Ow7N9wKg==",
       "dependencies": {
         "@remix-run/router": "1.21.0",
-        "@remix-run/server-runtime": "2.15.0",
+        "@remix-run/server-runtime": "2.15.1",
         "react-router": "6.28.0",
         "react-router-dom": "6.28.0",
         "turbo-stream": "2.4.0"
@@ -1699,13 +1695,12 @@
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.15.0.tgz",
-      "integrity": "sha512-Me78FMVKtBRUi6i2PKfP6t7coHHEjDl5IIV7loMm3HCMzc1iP35bRjv3F7nKcTknaiK/Zhsic1lrKt9jevAb/A==",
-      "license": "MIT",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.15.1.tgz",
+      "integrity": "sha512-NRpAEpqy670jMY3SX5fzu/jKD8Kb4vlLS3k1xksjnjZSjSyaH2fGCsxvlbDpSOCucukMeTEKU424iiScWsDBtg==",
       "dependencies": {
-        "@remix-run/express": "2.15.0",
-        "@remix-run/node": "2.15.0",
+        "@remix-run/express": "2.15.1",
+        "@remix-run/node": "2.15.1",
         "chokidar": "^3.5.3",
         "compression": "^1.7.4",
         "express": "^4.20.0",
@@ -1721,10 +1716,9 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.15.0.tgz",
-      "integrity": "sha512-FuM8vAg1sPskf4wn0ivbuj/7s9Qdh2wnKu+sVXqYz0a95gH5b73TuMzk6n3NMSkFVKKc6+UmlG1WLYre7L2LTg==",
-      "license": "MIT",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.15.1.tgz",
+      "integrity": "sha512-TDM3rzax//N2F5uNMV5pNTWAop8cYul6hteDu+Xmfwys/eRGlbzEf7YJzyRj6Kcsg2TFVHI7+xEPItGAVm1hHA==",
       "dependencies": {
         "@remix-run/router": "1.21.0",
         "@types/cookie": "^0.6.0",
@@ -2100,8 +2094,7 @@
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -3527,7 +3520,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4991,10 +4983,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
-      "license": "MIT",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5015,7 +5006,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -5030,6 +5021,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -8104,9 +8099,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -8114,7 +8109,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -8619,10 +8613,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/pathe": {
       "version": "1.1.2",


### PR DESCRIPTION
There were some vulnerabilitys in the packages (I noticed it by running `npm install`)
![grafik](https://github.com/user-attachments/assets/3540e4eb-ecc5-4aad-8f57-e43862296768)
This can be addressed by running `npm audit fix`
After updating, the vulnerabilitys are gone (I can see that by running `npm install` again)
![grafik](https://github.com/user-attachments/assets/1b7216df-510e-4592-8036-de212b2869b4)
