### PR TITLE
added test cases for restapi

### DIFF
--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -8,6 +8,86 @@ from .models import Tag, Mission, Mission_tags, File, Mission_files
 import logging
 import urllib.parse
 
+class RestApiPostMissionTestCase(APITestCase):
+    def setUp(self):
+        self.fristMission = Mission.objects.create(
+            name="TestMission",
+            date="2024-10-29",
+            location="TestLocation",
+            other="TestOther",
+        )
+        self.secondMission = Mission.objects.create(
+            name="TestMission2",
+            date="2024-10-29",
+            location="TestLocation2",
+            other="TestOther2",
+        )
+    
+    def test_get_missions(self):
+        response = self.client.get(reverse("get_missions"), format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(
+            response.data[0],
+            {
+                "id": self.fristMission.id,
+                "name": "TestMission",
+                "date": "2024-10-29",
+                "location": "TestLocation",
+                "other": "TestOther",
+            },
+        )
+        self.assertEqual(
+            response.data[1],
+            {
+                "id": self.secondMission.id,
+                "name": "TestMission2",
+                "date": "2024-10-29",
+                "location": "TestLocation2",
+                "other": "TestOther2",
+            },
+        )
+
+    def test_get_by_id(self):
+        response = self.client.get(
+            reverse("mission_detail", kwargs={"pk": self.fristMission.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data,
+            {
+                "id": self.fristMission.id,
+                "name": "TestMission",
+                "date": "2024-10-29",
+                "location": "TestLocation",
+                "other": "TestOther",
+            },
+        )
+    
+    def test_put_by_id(self):
+        response = self.client.put(
+            reverse("mission_detail", kwargs={"pk": self.fristMission.id}),
+            {"name": "TestMissionUpdated", "date": "2024-10-29", "location": "TestLocation", "other": "TestOther"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data,
+            {
+                "id": self.fristMission.id,
+                "name": "TestMissionUpdated",
+                "date": "2024-10-29",
+                "location": "TestLocation",
+                "other": "TestOther",
+            },
+        )
+    
+    def test_delete_by_id(self):
+        response = self.client.delete(
+            reverse("mission_detail", kwargs={"pk": self.secondMission.id})
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(Mission.objects.filter(id=self.secondMission.id)), 0)
 
 class TagTestCase(TestCase):
     test_names = list()

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -11,7 +11,7 @@ import urllib.parse
 
 class RestApiPostMissionTestCase(APITestCase):
     def setUp(self):
-        self.fristMission = Mission.objects.create(
+        self.firstMission = Mission.objects.create(
             name="TestMission",
             date="2024-10-29",
             location="TestLocation",
@@ -31,7 +31,7 @@ class RestApiPostMissionTestCase(APITestCase):
         self.assertEqual(
             response.data[0],
             {
-                "id": self.fristMission.id,
+                "id": self.firstMission.id,
                 "name": "TestMission",
                 "date": "2024-10-29",
                 "location": "TestLocation",
@@ -51,14 +51,14 @@ class RestApiPostMissionTestCase(APITestCase):
 
     def test_get_by_id(self):
         response = self.client.get(
-            reverse("mission_detail", kwargs={"pk": self.fristMission.id}),
+            reverse("mission_detail", kwargs={"pk": self.firstMission.id}),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data,
             {
-                "id": self.fristMission.id,
+                "id": self.firstMission.id,
                 "name": "TestMission",
                 "date": "2024-10-29",
                 "location": "TestLocation",
@@ -68,7 +68,7 @@ class RestApiPostMissionTestCase(APITestCase):
 
     def test_put_by_id(self):
         response = self.client.put(
-            reverse("mission_detail", kwargs={"pk": self.fristMission.id}),
+            reverse("mission_detail", kwargs={"pk": self.firstMission.id}),
             {
                 "name": "TestMissionUpdated",
                 "date": "2024-10-29",
@@ -81,7 +81,7 @@ class RestApiPostMissionTestCase(APITestCase):
         self.assertEqual(
             response.data,
             {
-                "id": self.fristMission.id,
+                "id": self.firstMission.id,
                 "name": "TestMissionUpdated",
                 "date": "2024-10-29",
                 "location": "TestLocation",

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -8,6 +8,7 @@ from .models import Tag, Mission, Mission_tags, File, Mission_files
 import logging
 import urllib.parse
 
+
 class RestApiPostMissionTestCase(APITestCase):
     def setUp(self):
         self.fristMission = Mission.objects.create(
@@ -22,7 +23,7 @@ class RestApiPostMissionTestCase(APITestCase):
             location="TestLocation2",
             other="TestOther2",
         )
-    
+
     def test_get_missions(self):
         response = self.client.get(reverse("get_missions"), format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -50,7 +51,8 @@ class RestApiPostMissionTestCase(APITestCase):
 
     def test_get_by_id(self):
         response = self.client.get(
-            reverse("mission_detail", kwargs={"pk": self.fristMission.id}), format="json"
+            reverse("mission_detail", kwargs={"pk": self.fristMission.id}),
+            format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -63,11 +65,16 @@ class RestApiPostMissionTestCase(APITestCase):
                 "other": "TestOther",
             },
         )
-    
+
     def test_put_by_id(self):
         response = self.client.put(
             reverse("mission_detail", kwargs={"pk": self.fristMission.id}),
-            {"name": "TestMissionUpdated", "date": "2024-10-29", "location": "TestLocation", "other": "TestOther"},
+            {
+                "name": "TestMissionUpdated",
+                "date": "2024-10-29",
+                "location": "TestLocation",
+                "other": "TestOther",
+            },
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -81,13 +88,14 @@ class RestApiPostMissionTestCase(APITestCase):
                 "other": "TestOther",
             },
         )
-    
+
     def test_delete_by_id(self):
         response = self.client.delete(
             reverse("mission_detail", kwargs={"pk": self.secondMission.id})
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(Mission.objects.filter(id=self.secondMission.id)), 0)
+
 
 class TagTestCase(TestCase):
     test_names = list()


### PR DESCRIPTION
Hey there, 

this PR adds test cases for the REST API. As the test cases for working with tags have already been included, I've added the general GET and POST Requests, as well as all requests that are working with mission ids.

The test cases are located in [`backend\restapi\tests.py`](https://github.com/brendel-group/mission_db/blob/ec81992a5b54431415d40e98004e99657efc84b8/backend/restapi/tests.py) and running them works by using `python manage.py test restapi`

Hope I covered everything, feel free to point out any cases I forgot :)

This would resolve #60 