### PR TITLE
Fix Mission table required fields and DATABASE_URL

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -37,6 +37,7 @@ jobs:
         echo "DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}" >> $GITHUB_ENV
         echo "DATABASE_HOST=localhost" >> $GITHUB_ENV
         echo "DATABASE_PORT=5432" >> $GITHUB_ENV
+        echo "DATABASE_URL=postgres://${{ secrets.DATABASE_USER }}:${{ secrets.DATABASE_PASSWORD }}@localhost:5432/${{ secrets.DATABASE_NAME }}" >> $GITHUB_ENV
   
     - name: Run migrations
       run: |

--- a/backend/restapi/models.py
+++ b/backend/restapi/models.py
@@ -12,7 +12,7 @@ class Mission(models.Model):
     other = models.CharField(max_length=65536, null=True, blank=True)
 
     class Meta:
-        unique_together = ["name", "date", "location", "other"]
+        unique_together = ["name", "date"]
 
     # this function defines, what the value of print(mission) would be
     def __str__(self):

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -219,7 +219,7 @@ class CapturedOutputTest(TestCase):
 
     def test_print_mission_table(self):
         missions = [
-            Mission.objects.create(name="Test", date="2024-12-02") for i in range(3)
+            Mission.objects.create(name=f"Test{i}", date="2024-12-02") for i in range(3)
         ]
         serializer = MissionSerializer(missions, many=True)
         cli.print_table(serializer.data)
@@ -228,9 +228,9 @@ class CapturedOutputTest(TestCase):
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
             "id│name│date│location│other\n"
             + "┼┼┼┼\n"
-            + f"{missions[0].id}│Test│2024-12-02│None│None\n"
-            + f"{missions[1].id}│Test│2024-12-02│None│None\n"
-            + f"{missions[2].id}│Test│2024-12-02│None│None",
+            + f"{missions[0].id}│Test0│2024-12-02│None│None\n"
+            + f"{missions[1].id}│Test1│2024-12-02│None│None\n"
+            + f"{missions[2].id}│Test2│2024-12-02│None│None",
         )
 
     def test_print_tag_table(self):

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -175,12 +175,12 @@ class AddMissionTests(TestCase):
         )
         cli.add_mission("TestAddMission", "2024-12-02")
         self.assertEqual(
-            len(Mission.objects.filter(name="TestAddMission", date="2024-12-02")), 2
+            len(Mission.objects.filter(name="TestAddMission", date="2024-12-02")), 1
         )
-        cli.add_mission("TestAddMission", "2024-12-02", other="other")
+        cli.add_mission("TestAddMission2", "2024-12-02", other="other")
         self.assertTrue(
             Mission.objects.filter(
-                name="TestAddMission", date="2024-12-02", other="other"
+                name="TestAddMission2", date="2024-12-02", other="other"
             ).exists()
         )
 


### PR DESCRIPTION
I noticed that since 
```python
unique_together = ["name", "date", "location", "other"]
```
was added to prevent duplicates, the fields `location` and `other` became required.\
Since it is intended, that these fields are optional and we want to prevent duplicates I changed it to
```python
unique_together = ["name", "date"]
```
since these are the only required fields.\
 So now there can't be 2 Missions with the same name and date.

And because #102 was merged we now need to use DATABASE_URL instead of DATABASE_NAME, DATABASE_USER, ... in our `.env` file and also in github actions, so I changed that in github actions.