### PR TITLE
New handling of null cases in the detail view and in overview

### DIFF
--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -26,7 +26,7 @@ export function ShowDatasets({ data }: { data: DetailViewData }) {
     </Table.Tr>
   ));
 
-  // Returns the filled table with DatasetView, which is opend on state change
+  // Returns the filled table with DatasetView
   return (
     <>
       <Table>

--- a/frontend/app/pages/details/DetailsView.tsx
+++ b/frontend/app/pages/details/DetailsView.tsx
@@ -22,14 +22,15 @@ const DetailsView: React.FC<DetailsViewProps> = ({
     <AbstractPage
       headline={
         selectedRow
-          ? `${selectedRow.name}, ${selectedRow.location} with ${selectedRow.robot}`
+          ? `${selectedRow.name}${selectedRow.location ? `, ${selectedRow.location}` : ""}${selectedRow.robot ? ` with ${selectedRow.robot}` : ""
+          }`
           : "Mission Details"
       }
     >
       {/* Main content */}
-      <Grid gutter="md">
+      < Grid gutter="md" >
         {/* Left column occupying 80% */}
-        <Grid.Col span={9}>
+        < Grid.Col span={9} >
           <Grid gutter="md">
             {/* Tags */}
             <Grid.Col span={12}>
@@ -45,14 +46,14 @@ const DetailsView: React.FC<DetailsViewProps> = ({
               {detailViewData && <ShowDatasets data={detailViewData} />}
             </Grid.Col>
           </Grid>
-        </Grid.Col>
+        </Grid.Col >
 
         {/* Stats */}
-        <Grid.Col span={3}>
+        < Grid.Col span={3} >
           <ShowStatsView missionData={selectedRow} />
-        </Grid.Col>
-      </Grid>
-    </AbstractPage>
+        </Grid.Col >
+      </Grid >
+    </AbstractPage >
   );
 };
 

--- a/frontend/app/pages/details/StatsView.tsx
+++ b/frontend/app/pages/details/StatsView.tsx
@@ -17,7 +17,7 @@ export const ShowStatsView: React.FC<ShowStatsViewProps> = ({
       </Text>
       <Text>Total Duration: {missionData.totalDuration}</Text>
       <Text>Total Size: {missionData.totalSize} GB</Text>
-      <Text>Remarks: {missionData.remarks}</Text>
+      <Text>Remarks: {missionData.remarks === null ? "None" : missionData.remarks}</Text>
     </div>
   );
 };

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -206,11 +206,11 @@ export function Overview() {
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "")}
     >
       <Table.Td>{row.name}</Table.Td>
-      <Table.Td>{row.location === null ? "None" : row.location}</Table.Td>
+      <Table.Td>{row.location === null ? "" : row.location}</Table.Td>
       <Table.Td>{row.totalDuration}</Table.Td>
       <Table.Td>{row.totalSize}</Table.Td>
       <Table.Td>{row.robot}</Table.Td>
-      <Table.Td>{row.remarks === null ? "None" : row.remarks}</Table.Td>
+      <Table.Td>{row.remarks === null ? "" : row.remarks}</Table.Td>
       <Table.Td
         onClick={(e) => e.stopPropagation()}
         style={{ cursor: "default" }}

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -206,11 +206,11 @@ export function Overview() {
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "")}
     >
       <Table.Td>{row.name}</Table.Td>
-      <Table.Td>{row.location}</Table.Td>
+      <Table.Td>{row.location === null ? "None" : row.location}</Table.Td>
       <Table.Td>{row.totalDuration}</Table.Td>
       <Table.Td>{row.totalSize}</Table.Td>
       <Table.Td>{row.robot}</Table.Td>
-      <Table.Td>{row.remarks}</Table.Td>
+      <Table.Td>{row.remarks === null ? "None" : row.remarks}</Table.Td>
       <Table.Td
         onClick={(e) => e.stopPropagation()}
         style={{ cursor: "default" }}

--- a/frontend/app/utilities/fetchapi.ts
+++ b/frontend/app/utilities/fetchapi.ts
@@ -99,7 +99,7 @@ export const fetchAndTransformMission = async (
           totalDuration: exampleData?.totalDuration || "",
           totalSize: exampleData?.totalSize || "",
           robot: exampleData?.robot || "",
-          remarks: mission.other || "",
+          remarks: mission.other,
           tags: tags || [],
         };
   
@@ -129,7 +129,7 @@ export const fetchAndTransformMissions = async (): Promise<MissionData[]> => {
                     totalDuration: exampleData?.totalDuration || "",
                     totalSize: exampleData?.totalSize || "",
                     robot: exampleData?.robot || "",
-                    remarks: missions[i].other || "",
+                    remarks: missions[i].other,
                     tags: tags || []
                 }
             )


### PR DESCRIPTION
Hi,
this pr addresses issue #139

I implemented a new handling for null cases in remarks and location, the problem was the following:
And null appears in detail view:
![image](https://github.com/user-attachments/assets/659760a1-4ea3-43de-8349-c12c8a97da57)
This is addressed by new checks and changes to the headline in detail view:
![image](https://github.com/user-attachments/assets/84ced7f2-8cb6-4f0d-9b73-d80c36eadae6)
