### PR TITLE
Introduced date field to detail view and overview table

### DIFF
--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -23,14 +23,16 @@ export interface MissionData {
 //This is a local representation used for mission table and details view
 export interface RenderedMission {
   id: number;
-
+  // Pure mission fields
   name: string;
   location: string;
+  date: string;
+  notes: string;
+
+  // Inherited from other data structures (details, tags, ...)
   totalDuration: string;
   totalSize: string;
   robot: string;
-  notes: string;
-
   tags: Tag[];
 }
 

--- a/frontend/app/pages/details/InformationView.tsx
+++ b/frontend/app/pages/details/InformationView.tsx
@@ -92,6 +92,7 @@ export const ShowInformationView: React.FC<ShowInformationViewProps> = ({
       <Text size="xl" mb="sm">
         Information
       </Text>
+      <Text>Date: {missionData.date}</Text>
       <Text>Total Duration: {missionData.totalDuration}</Text>
       <Text>Total Size: {missionData.totalSize} GB</Text>
 

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -158,10 +158,11 @@ export function Overview() {
             id: missions[i].id,
             name: missions[i].name,
             location: missions[i].location,
+            date: missions[i].date,
+            notes: missions[i].notes,
             totalDuration: "00:00:00", // this fields need to be overriden in the future
             totalSize: "0",
             robot: "Vader",
-            notes: missions[i].notes,
             tags: tags || [],
           });
         }
@@ -229,6 +230,7 @@ export function Overview() {
       <Table.Td>{row.totalDuration}</Table.Td>
       <Table.Td>{row.totalSize}</Table.Td>
       <Table.Td>{row.robot}</Table.Td>
+      <Table.Td>{row.date}</Table.Td>
       <Table.Td>{row.notes === null ? "" : row.notes}</Table.Td>
       <Table.Td
         onClick={(e) => e.stopPropagation()}
@@ -350,6 +352,7 @@ export function Overview() {
     { key: "totalDuration", label: "Duration" },
     { key: "totalSize", label: "Size (MB)" },
     { key: "robot", label: "Robot" },
+    { key: "date", label: "Date" },
     { key: "notes", label: "Notes" },
     { key: "tags", label: "Tags" },
   ];

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -51,10 +51,11 @@ function Detail() {
           id: mission.id,
           name: mission.name,
           location: mission.location,
+          date: mission.date,
+          notes: mission.notes,
           totalDuration: "00:00:00",
           totalSize: "0",
           robot: "?",
-          notes: mission.notes,
           tags: tags || [],
         };
 


### PR DESCRIPTION
Hi, this PR introduces the date field into the mission table:
![image](https://github.com/user-attachments/assets/38d4956b-0e3c-48c8-a545-6bfce449ea5a)
And in the detail view:
![image](https://github.com/user-attachments/assets/098210f5-2bbd-4469-add8-1b81f02e4fdc)

Also made clear by additional comments, what is part of the actual mission backend data, and what is obtained by other structures:
```
//This is a local representation used for mission table and details view
export interface RenderedMission {
  id: number;
  // Pure mission fields
  name: string;
  location: string;
  date: string;
  notes: string;

  // Inherited from other data structures (details, tags, ...)
  totalDuration: string;
  totalSize: string;
  robot: string;
  tags: Tag[];
}
```

Should we rearrange the rows in the mission table?

This PR addresses issue #137 