### PR TITLE
Make the CLI use a pager

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -9,6 +9,7 @@ import logging
 import shlex
 import code
 from datetime import datetime
+from pydoc import pager
 
 try:
     import readline
@@ -129,6 +130,8 @@ def print_table(list_of_dict: list[dict]):
         list_of_widths.append(len(key))
         widths[key] = max(list_of_widths)
 
+    table = ""
+
     # print header
 
     header = ""
@@ -138,11 +141,8 @@ def print_table(list_of_dict: list[dict]):
         vertical_line += horizontal_bar * (widths[key] + 1) + cross_bar + horizontal_bar
 
     # remove last 3 characters because there is no extra column
-    header = header[:-3]
-    vertical_line = vertical_line[:-3]
-
-    print(header)
-    print(vertical_line)
+    table += header[:-3] + "\n"
+    table += vertical_line[:-3] + "\n"
 
     # print content
 
@@ -150,8 +150,9 @@ def print_table(list_of_dict: list[dict]):
         line = ""
         for key in keys:
             line += f"{str(entry[key]):<{widths[key]}} {vertical_bar} "
-        line = line[:-3]
-        print(line)
+        table += line[:-3] + "\n"
+
+    pager(table)
 
 
 def add_mission_from_folder(folder_path, location=None, notes=None):

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -156,7 +156,12 @@ def print_table(list_of_dict: list[dict]):
 
     table = table[:-1]
 
-    terminal_cols, terminal_rows = os.get_terminal_size()
+    try:
+        terminal_cols, terminal_rows = os.get_terminal_size()
+    except Exception:
+        terminal_cols = float("inf")
+        terminal_rows = float("inf")
+
     terminal_rows -= 1  # the bottom line in interactive mode is the input line
     text_rows = table.count("\n") + 1
     text_cols = len(vertical_line)

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -141,8 +141,10 @@ def print_table(list_of_dict: list[dict]):
         vertical_line += horizontal_bar * (widths[key] + 1) + cross_bar + horizontal_bar
 
     # remove last 3 characters because there is no extra column
-    table += header[:-3] + "\n"
-    table += vertical_line[:-3] + "\n"
+    header = header[:-3]
+    vertical_line = vertical_line[:-3]
+    table += header + "\n"
+    table += vertical_line + "\n"
 
     # print content
 
@@ -152,7 +154,17 @@ def print_table(list_of_dict: list[dict]):
             line += f"{str(entry[key]):<{widths[key]}} {vertical_bar} "
         table += line[:-3] + "\n"
 
-    pager(table)
+    table = table[:-1]
+
+    terminal_cols, terminal_rows = os.get_terminal_size()
+    terminal_rows -= 1  # the bottom line in interactive mode is the input line
+    text_rows = table.count("\n") + 1
+    text_cols = len(vertical_line)
+
+    if (text_cols > terminal_cols) or (text_rows > terminal_rows):
+        pager(table)
+    else:
+        print(table)
 
 
 def add_mission_from_folder(folder_path, location=None, notes=None):

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -6,6 +6,7 @@ import cli
 import logging
 from io import StringIO
 import sys
+import os
 from unittest.mock import patch
 
 
@@ -192,9 +193,19 @@ class CapturedOutputTest(TestCase):
         self.captured_output = StringIO()
         sys.stdout = self.captured_output
 
+        self.patcher_os_terminal_size = patch(
+            "os.get_terminal_size",
+            return_value=os.terminal_size(
+                os.terminal_size((float("inf"), float("inf")))
+            ),
+        )
+        self.patcher_os_terminal_size.start()
+
     def tearDown(self):
         self.mission.delete()
         sys.stdout = self.original_stdout
+
+        self.patcher_os_terminal_size.stop()
 
     def test_remove_misison(self):
         cli.remove_mission(self.mission.id)
@@ -255,10 +266,18 @@ class MainFunctionTests(TestCase):
         self.captured_output = StringIO()
         sys.stdout = self.captured_output
 
+        self.patcher_os_terminal_size = patch(
+            "os.get_terminal_size",
+            return_value=os.terminal_size((float("inf"), float("inf"))),
+        )
+        self.patcher_os_terminal_size.start()
+
     def tearDown(self):
         self.mission.delete()
         sys.stdout.flush()
         sys.stdout = self.original_stdout
+
+        self.patcher_os_terminal_size.stop()
 
     def test_mission_add(self):
         args = [
@@ -426,11 +445,19 @@ class TagBasicTests(TestCase):
         self.captured_output = StringIO()
         sys.stdout = self.captured_output
 
+        self.patcher_os_terminal_size = patch(
+            "os.get_terminal_size",
+            return_value=os.terminal_size((float("inf"), float("inf"))),
+        )
+        self.patcher_os_terminal_size.start()
+
         # Setting up environment, creating common tags
         self.tag = Tag.objects.create(name="TestTag", color="#FFFFFF")
 
     def tearDown(self):
         self.logger.disabled = False
+
+        self.patcher_os_terminal_size.stop()
 
         sys.stdout.flush()
         sys.stdout = self.original_stdout
@@ -466,6 +493,12 @@ class ListMissionTagTests(TestCase):
         self.captured_output = StringIO()
         sys.stdout = self.captured_output
 
+        self.patcher_os_terminal_size = patch(
+            "os.get_terminal_size",
+            return_value=os.terminal_size((float("inf"), float("inf"))),
+        )
+        self.patcher_os_terminal_size.start()
+
         self.mission = Mission(name="Test", date=date.today())
         self.mission.save()
 
@@ -482,6 +515,8 @@ class ListMissionTagTests(TestCase):
     def tearDown(self):
         sys.stdout.flush()
         sys.stdout = self.original_stdout
+
+        self.patcher_os_terminal_size.stop()
 
     def test_list_tags_by_mission(self):
         cli.list_tags_by_mission(self.mission.id)

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -195,9 +195,7 @@ class CapturedOutputTest(TestCase):
 
         self.patcher_os_terminal_size = patch(
             "os.get_terminal_size",
-            return_value=os.terminal_size(
-                os.terminal_size((float("inf"), float("inf")))
-            ),
+            return_value=os.terminal_size((float("inf"), float("inf"))),
         )
         self.patcher_os_terminal_size.start()
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -40,6 +40,10 @@ Use
 to display help information\
 `--help` can be called on every command and subcommand
 
+When the output is too wide or long for the terminal and is a table, a pager will be used to display the table.\
+The pager can be set usin the  `PAGER` or `MANPAGER` environmental variables.\
+On Debian systems the default pager is `less` in most cases. With `less` the option `-S` can be used to disable folding of long lines to correctly display the table.
+
 ### `cli.py mission`
 
 command to make changes to missions


### PR DESCRIPTION
When the CLI prints a table it can happen that the table is too wide for the terminal window and the formatting is messed up and basically unusable.\
To fix this I used to pipe the output of the cli to `less` where I could use the option `-S` and the table gets displayed correctly and I can scroll up, down, left and right with the arrow keys and search for words. Like this:
```bash
./cli.py mission list | less -S
```

With the interactive mode this won't work.\
So I made it that when a table is too wide it automatically gets displayed by a pager that is selected by the `PAGER` or `MANPAGER` environment variable or a default pager.\
For Linux the default pager in most cases is `less`.\
When your pager is `less` you can type in `-S` after it opened to disable long line folding to correctly see the table.

For Windows there is no default pager and it just prints the table, but you can set the `PAGER` environment variable to any pager you like. 

## How to test:
1. Create for example a mission with a name and notes that is too long to be displayed in one line on your terminal.
2. use `python cli.py mission list` or the interactive mode to display the table in a pager or print it.