### PR TITLE
CLI interactive mode improvements

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -30,7 +30,7 @@ from rest_framework_api_key.models import APIKey  # noqa
 logging.basicConfig(level=logging.INFO)
 
 env = environ.Env(USE_UNICODE=(bool, True))
-environ.Env.read_env()
+environ.Env.read_env("./backend/.env")
 
 USE_UNICODE = env("USE_UNICODE")
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -9,6 +9,7 @@ import logging
 import shlex
 import code
 import traceback
+import environ
 from datetime import datetime
 
 try:
@@ -25,10 +26,13 @@ from restapi.models import Mission, Tag, Mission_tags  # noqa
 from restapi.serializer import MissionSerializer, TagSerializer  # noqa
 from rest_framework_api_key.models import APIKey  # noqa
 
-USE_UNICODE = os.getenv("USE_UNICODE", "True") == "True"
-
 # Set up logging
 logging.basicConfig(level=logging.INFO)
+
+env = environ.Env(USE_UNICODE=(bool, True))
+environ.Env.read_env()
+
+USE_UNICODE = env("USE_UNICODE")
 
 # set up repl
 REPL_HISTFILE = os.path.expanduser("~/.polybot_mission_db_cli.py_hist")

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -134,7 +134,9 @@ def print_table(list_of_dict: list[dict]):
     widths = {}
 
     for key in keys:
-        list_of_widths = list(map(lambda d: len(str(d[key])), list_of_dict))
+        list_of_widths = list(
+            map(lambda d: get_width_of_multiline_string(str(d[key])), list_of_dict)
+        )
         list_of_widths.append(len(key))
         widths[key] = max(list_of_widths)
 
@@ -157,10 +159,44 @@ def print_table(list_of_dict: list[dict]):
 
     for entry in list_of_dict:
         line = ""
+        next_line = {}
+
+        # add normal content, but only first line
         for key in keys:
-            line += f"{str(entry[key]):<{widths[key]}} {vertical_bar} "
+            content = str(entry[key])
+            if "\n" in content:
+                # extract first line and store remaining lines in next_line dict
+                splitted = content.split("\n")
+                content = splitted[0]
+                next_line[key] = splitted[1:]
+
+            line += f"{content:<{widths[key]}} {vertical_bar} "
+
+        # add remaining lines
+        while next_line:
+            # trim line
+            line = line[:-3]
+            line += "\n"
+
+            for key in keys:
+                # add empty field or content
+                if key in next_line:
+                    contents = next_line[key]
+                    content = str(contents.pop(0))
+                    if not contents:
+                        del next_line[key]
+
+                    line += f"{content:<{widths[key]}} {vertical_bar} "
+                else:
+                    line += f"{" ":<{widths[key]}} {vertical_bar} "
+
         line = line[:-3]
         print(line)
+
+
+def get_width_of_multiline_string(str: str):
+    widths = map(len, str.split("\n"))
+    return max(widths)
 
 
 def add_mission_from_folder(folder_path, location=None, notes=None):

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -590,7 +590,15 @@ class Interactive(code.InteractiveConsole):
         self.help = help
 
     def runsource(self, source, filename="<input>", symbol="single"):
-        args = shlex.split(source)
+        try:
+            args = shlex.split(source)
+        except ValueError as e:
+            if "No closing quotation" in e.args:
+                # will ask for more input when True returned
+                return True
+            else:
+                raise e
+
         if not args:
             return
         if "exit" in args:
@@ -611,9 +619,8 @@ class Interactive(code.InteractiveConsole):
 
 
 def interactive(parser: argparse.ArgumentParser, subparser):
-    if subparser:
-        subparser.add_parser("exit", help="exit the command prompt")
-        subparser.add_parser("help", help="show this help message")
+    subparser.add_parser("exit", help="exit the command prompt")
+    subparser.add_parser("help", help="show this help message")
 
     if readline:
         if os.path.exists(REPL_HISTFILE):

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -8,6 +8,7 @@ import django
 import logging
 import shlex
 import code
+import traceback
 from datetime import datetime
 
 try:
@@ -593,6 +594,8 @@ def interactive(parser: argparse.ArgumentParser):
         )
     except SystemExit:
         pass
+    except Exception:
+        print(traceback.format_exc())
 
     if readline:
         readline.set_history_length(REPL_HISTFILE_SIZE)

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -24,6 +24,8 @@ from restapi.models import Mission, Tag, Mission_tags  # noqa
 from restapi.serializer import MissionSerializer, TagSerializer  # noqa
 from rest_framework_api_key.models import APIKey  # noqa
 
+USE_UNICODE = False
+
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 
@@ -111,9 +113,14 @@ def print_table(list_of_dict: list[dict]):
     ### Parameters
     list_of_dict: A list containing flat dictionaries which all have the same keys
     """
-    vertical_bar = "│"  # U+2502
-    horizontal_bar = "─"  # U+2500
-    cross_bar = "┼"  # U+253C
+    if USE_UNICODE:
+        vertical_bar = "│"  # U+2502
+        horizontal_bar = "─"  # U+2500
+        cross_bar = "┼"  # U+253C
+    else:
+        vertical_bar = "|"
+        horizontal_bar = "-"
+        cross_bar = "+"
 
     if not list_of_dict:
         print("Empty list nothing to display")

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -25,7 +25,7 @@ from restapi.models import Mission, Tag, Mission_tags  # noqa
 from restapi.serializer import MissionSerializer, TagSerializer  # noqa
 from rest_framework_api_key.models import APIKey  # noqa
 
-USE_UNICODE = False
+USE_UNICODE = True
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -574,7 +574,11 @@ class Interactive(code.InteractiveConsole):
             pass
 
 
-def interactive(parser: argparse.ArgumentParser):
+def interactive(parser: argparse.ArgumentParser, subparser):
+    if subparser:
+        subparser.add_parser("exit", help="exit the command prompt")
+        subparser.add_parser("help", help="show this help message")
+
     if readline:
         if os.path.exists(REPL_HISTFILE):
             try:
@@ -845,7 +849,7 @@ def main(args):
         case "api-key":
             api_key_command(api_key_parser, args)
         case _:
-            interactive(parser)
+            interactive(parser, subparser)
 
 
 if __name__ == "__main__":

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -25,7 +25,7 @@ from restapi.models import Mission, Tag, Mission_tags  # noqa
 from restapi.serializer import MissionSerializer, TagSerializer  # noqa
 from rest_framework_api_key.models import APIKey  # noqa
 
-USE_UNICODE = True
+USE_UNICODE = os.getenv("USE_UNICODE", "True") == "True"
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -653,6 +653,7 @@ class PrintTableTests(TestCase):
         self.original_stdout = sys.stdout
         self.captured_output = StringIO()
         sys.stdout = self.captured_output
+        cli.USE_UNICODE = True
 
     def tearDown(self):
         self.mission.delete()

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,5 +1,9 @@
 # Command-line Interface
 
+When listing for example Missions the output is a table that uses unicode characters for nice formatting,\
+but if your terminal doesn't support unicode you can disable this by setting the envirment variable `USE_UNICODE` to `False` in the .env file.\
+The table will then be printed using ASCII characters.
+
 ## Interactive mode:
 Executing `cli.py` without any arguments will start an interactive shell mode.\
 Every argument is available as a command in the shell.\
@@ -28,6 +32,22 @@ id │ name                          │ date       │ location │ notes
 1  │ Example for interactive shell │ 2024-12-10 │ None     │ None 
 >>> exit
 ```
+
+It's possible to input multiple lines when using quotes.
+Example:
+```bash
+./cli.py
+cli.py interactive mode
+  type 'help' for help or 'exit' to exit
+>>> mission add --name "Multi
+... line
+... example" --date "2024-12-26"
+INFO:root:'Multi
+line
+example' added.
+>>> exit
+```
+Strings with linebreaks are also supported when listing something in a table.
 
 ## Argument mode:
 


### PR DESCRIPTION
I made some improvements for the interactive mode and the CLI in general:
1. When the output is a table it uses Unicode characters for the lines in the table. This behavior is now optional and can be disabled with the environment variable `USE_UNICODE` that can be set to `False` in the .env file. It then uses ASCII characters.
2. The table now correctly displays strings that contain newlines (`\n`). It now prints the second or more lines of such a string in a new line that contains only empty fields or the respective content.
3. The interactive mode now supports multi line input when using quotes. Previously it was only possible to have multi line strings when using arguments and not the interactive mode.
4. When an exception is thrown when using the interactive mode it is printed like normal and the interactive mode is terminated correctly (writing the history to file and potentially more)

I added documentation for the environment variable `USE_UNICODE` and the multi line input.\
And I added a test for the output of multi line strings in the table.

I added the option to disable the usage of Unicode characters, because when using the pager added in #151 on windows with setting `PAGER=less` it doesn't support Unicode characters and prints something unreadable.

## How to test
Use the CLI with the interactive mode and try adding a mission that contains more than one line in the name or notes field.\
Then test the output using `mission list`.
Set `USE_UNICODE=False` in the backend/backend/.env file and test the output again.