### PR TITLE
CLI use managment and API endpoints

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     "rest_framework_api_key",
     "restapi",
     "corsheaders",
+    "dj_rest_auth",
 ]
 
 MIDDLEWARE = [
@@ -145,3 +146,9 @@ if not DEBUG:
             "rest_framework_api_key.permissions.HasAPIKey",
         ]
     }
+
+# Authentication
+# https://dj-rest-auth.readthedocs.io/en/latest/configuration.html
+REST_AUTH = {
+    "TOKEN_MODEL": None,
+}

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -23,6 +23,7 @@ django.setup()
 from restapi.models import Mission, Tag, Mission_tags  # noqa
 from restapi.serializer import MissionSerializer, TagSerializer  # noqa
 from rest_framework_api_key.models import APIKey  # noqa
+from django.contrib.auth.models import User  # noqa
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -665,6 +666,20 @@ def api_key_command(api_key_parser, args):
             api_key_parser.print_help()
 
 
+def user_command(user_parser, args):
+    match args.user:
+        case "add":
+            pass
+        case "remove":
+            pass
+        case "change-password":
+            pass
+        case "list":
+            pass
+        case _:
+            pass
+
+
 def mission_arg_parser(subparser):
     """
     Parser setup for mission subcommand
@@ -803,6 +818,39 @@ def api_key_arg_parser(subparser: argparse._SubParsersAction):
     return api_key_parser
 
 
+def user_arg_parser(subparser: argparse._SubParsersAction):
+    user_parser: argparse.ArgumentParser = subparser.add_parser(
+        "user", help="Modifiy Users"
+    )
+    user_subparser: argparse._SubParsersAction = user_parser.add_subparsers(dest="user")
+
+    # Add command
+    add_parser: argparse.ArgumentParser = user_subparser.add_parser(
+        "add", help="Add User"
+    )
+    add_parser.add_argument("--name", help="User name")
+    add_parser.add_argument(
+        "--email", required=False, help="email of User"
+    )  # email is used when requesting password reset via API ENDPOINT
+
+    # Remove command
+    remove_parser: argparse.ArgumentParser = user_subparser.add_parser(
+        "remove", help="Remove User"
+    )
+    remove_parser.add_argument("--name", help="User name")
+
+    # change-password command
+    change_parser: argparse.ArgumentParser = user_subparser.add_parser(
+        "change-password", help="Change the password of a user"
+    )
+    change_parser.add_argument("--name", help="User name")
+
+    # List command
+    _ = user_subparser.add_parser("list", help="List all Users")
+
+    return user_subparser
+
+
 def main(args):
     # Arg parser
     parser = argparse.ArgumentParser(description="Mission CLI")
@@ -817,6 +865,8 @@ def main(args):
     tag_parser, tag_mission_parser = tag_arg_parser(subparser)
 
     api_key_parser = api_key_arg_parser(subparser)
+
+    user_parser = user_arg_parser(subparser)
 
     argcomplete.autocomplete(parser)
 
@@ -834,6 +884,8 @@ def main(args):
             tag_command(tag_parser, tag_mission_parser, args)
         case "api-key":
             api_key_command(api_key_parser, args)
+        case "user":
+            user_command(user_parser, args)
         case _:
             interactive(parser)
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -563,7 +563,7 @@ def add_user(name, email=None):
     try:
         password = read_and_validate_password()
     except ValidationError as e:
-        logging.error(e.message)
+        logging.error(e)
         return
 
     try:
@@ -580,7 +580,7 @@ def change_password(name):
     try:
         password = read_and_validate_password("New Password: ", "Verify new Password: ")
     except ValidationError as e:
-        logging.error(e.message)
+        logging.error(e)
         return
 
     try:
@@ -595,6 +595,7 @@ def change_password(name):
 
     try:
         user.set_password(password)
+        user.save()
     except Exception as e:
         logging.error(e)
         return

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -10,6 +10,8 @@ import shlex
 import code
 from datetime import datetime
 from django.core.exceptions import ValidationError
+from getpass import getpass
+
 
 try:
     import readline
@@ -547,13 +549,8 @@ def list_api_keys():
 def read_and_validate_password(
     prompt1="Password: ", prompt2="Verify Password: "
 ) -> str:
-    password = input(prompt1)
-    if readline:
-        readline.remove_history_item(readline.get_current_history_length() - 1)
-
-    password_verify = input(prompt2)
-    if readline:
-        readline.remove_history_item(readline.get_current_history_length() - 1)
+    password = getpass(prompt1)
+    password_verify = getpass(prompt2)
 
     if password != password_verify:
         raise ValidationError("The passwords do not match")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ pyreadline3; platform_system == 'Windows'
 ruff
 whitenoise
 djangorestframework-api-key==3.*
+dj-rest-auth==7.*

--- a/backend/restapi/urls.py
+++ b/backend/restapi/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import include, path
 from .views import (
     get_missions,
     create_mission,
@@ -37,4 +37,5 @@ urlpatterns = [
         name="delete_mission_tag",
     ),
     path("missions/<int:mission_id>/files/", get_files_by_mission_id, name="get_files"),
+    path("auth/", include("dj_rest_auth.urls")),
 ]

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -241,6 +241,51 @@ This will not display the keys itself.\
 It will display all information as stored in the database.\
 The keys itself are stored as hash values.
 
+### `cli.py user`
+Make changes to Users
+
+### `cli.py user add`
+Add a user
+
+Arguments:
+- `--name` username of new user
+- `--email` (optional) email-address of new user
+
+The password can not be given as an argument and must be entered interactively after the command.\
+For rules for a password refer to the [password policies](../password_policy/README.md)
+
+Example:
+```bash
+./cli.py user add --name test
+```
+will then ask for a password:
+```bash
+Password: 
+```
+and to verify the password:
+```bash
+Verify Password: 
+```
+
+### `cli.py user remove`
+Delete/remove a User.
+
+Arguments:
+- `--name` username of user to remove
+
+### `cli.py user change-password`
+Change the password of a User. Doesn't ask for the old password, just the new password.
+
+Arguments:
+- `--name` username of User which wants to change the password
+
+The password rules can be found [here](../password_policy/README.md)
+
+### `cli.py user list`
+Show all users.\
+Lists the Users with the data stored in the database.\
+The password is not stored in clear-text but as a hash value.
+
 ## Troubleshooting
 
 - ### `Error adding mission: duplicate key value violates unique constraint "restapi_mission_pkey"`

--- a/docs/password_policy/README.md
+++ b/docs/password_policy/README.md
@@ -1,0 +1,9 @@
+# Password Policy
+
+Currently these rules are active:
+1. The password has to be sufficiently different from certain attributes (username and email)
+2. It has to be at least 8 characters long
+3. It is checked against a list of common passwords and is not allowed to be in that list.
+4. It can not be entirely numeric.
+
+These rules are defined in `backend/backend/settings.py` in `AUTH_PASSWORD_VALIDATORS` more about available validators can be found [here](https://docs.djangoproject.com/en/5.1/topics/auth/passwords/#password-validation).

--- a/docs/restapi/README.md
+++ b/docs/restapi/README.md
@@ -19,7 +19,19 @@ For information on how to get an API KEY refer to the [cli documentation](https:
 - cd into the backend dir
 - run `python manage.py runserver`
 
-### using the webserver
+## authentication for the frontend
+Available URLs are:
+- `/restapi/auth/login/` (POST) returns 204 status code if credentials are valid. Creates django session
+- `/restapi/auth/logout/` (POST) Deletes django session
+- `/restapi/auth/user/` (GET,PUT,PATCH) User details
+- `/restapi/auth/password/change/` (POST) change password
+- `/restapi/auth/password/reset/` (POST) not usable until email delivery is supported
+- `/restapi/auth/password/reset/confirm/` (POST) also not usable until email delivery is supported
+
+This should only be a short overview about what is suported.\
+For more details about how to use the endpoints refer to the [dj-rest-auth documentation](https://dj-rest-auth.readthedocs.io/en/latest/api_endpoints.html).
+
+## using the webserver
 - GET Requests for missions
     - [GET Missions](http://127.0.0.1:8000/restapi/missions/) shows all stored missions in our database
 - POST Requests for missions


### PR DESCRIPTION
I added the package `dj-rest-auth` which provides REST API endpoints for login, logout and more.\
It would also be really easy to later add API endpoints for registration with this.

To manage users with the CLI I added the commands `user add`,`user remove`, `user change-password` and `user list` which are all documented in the [CLI documentation](https://github.com/brendel-group/mission_db/blob/feature/cli-user-management/docs/cli/README.md).

The passwords are validated using some rules set in settings.py in `AUTH_PASSWORD_VALIDATORS` I made a summary of these rules [here](https://github.com/brendel-group/mission_db/blob/feature/cli-user-management/docs/password_policy/README.md) (these are the default rules by django).

The password input is hidden and not stored in any history file.

The passwords are stored in the database as hash values. You can directly see how they are stored with the `user list` command of the CLI.

I made a short summary of the available REST API endpoints in the [restapi documentation](https://github.com/brendel-group/mission_db/blob/feature/cli-user-management/docs/restapi/README.md) and added a link to the complete documentation of `dj-rest-auth`.

I added tests for the CLI but not for the REST API since the endpoints are provided by a package and there is no implementation from our side, so I don't think we need tests for that.

It's possible to have users with an email but it's not required and not used currently. It would be possible to add password reset for forgotten passwords with the email, the API endpoints for this are already there but for this the server has to be able to send emails.

resolves #134 

## How to test
Create a user with the CLI and try to change the password, list and remove the user.\
Test the API endpoints with the created user and check the documentation for errors.