### PR TITLE
Tag picker custom color Input

### DIFF
--- a/frontend/app/config.tsx
+++ b/frontend/app/config.tsx
@@ -2,7 +2,7 @@
 export var USE_RANDOM_DATA = false;
 
 //URL of rest api
-export const FETCH_API_BASE_URL = 'http://127.0.0.1:8000/restapi';
+export const FETCH_API_BASE_URL = "http://127.0.0.1:8000/restapi";
 
 //Login system
-export const MAX_SESSION_AGES = 60 * 5; // 5 minutes
+export const MAX_SESSION_AGES = 60 * 60; // 5 minutes

--- a/frontend/app/config.tsx
+++ b/frontend/app/config.tsx
@@ -5,4 +5,4 @@ export var USE_RANDOM_DATA = false;
 export const FETCH_API_BASE_URL = "http://127.0.0.1:8000/restapi";
 
 //Login system
-export const MAX_SESSION_AGES = 60 * 60; // 5 minutes
+export const MAX_SESSION_AGES = 60 * 60; // 60 minutes

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -246,7 +246,7 @@ export function Overview() {
               {item.name}
             </Badge>
           ))}
-          <Menu>
+          <Menu closeOnClickOutside={false}>
             {/*edit button*/}
             <Menu.Target>
               <Badge color="grey" variant="light" style={{ cursor: "pointer" }}>
@@ -258,7 +258,14 @@ export function Overview() {
             </Menu.Target>
             {/*Actions for the Tag Picker*/}
             <Menu.Dropdown
-              style={{ padding: "10px", marginLeft: "-25px", marginTop: "2px" }}
+              style={{
+                padding: "10px",
+                marginLeft: "-25px",
+                marginTop: "2px",
+                maxHeight: "230px",
+                overflowY: "auto",
+                overflowX: "hidden",
+              }}
             >
               <TagPicker
                 tags={row.tags}

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -9,9 +9,9 @@ import {
   TextInput,
   rem,
   keys,
-  Menu,
   Skeleton,
   Badge,
+  Popover,
 } from "@mantine/core";
 import {
   IconSelector,
@@ -246,25 +246,23 @@ export function Overview() {
               {item.name}
             </Badge>
           ))}
-          <Menu closeOnClickOutside={false}>
+          <Popover>
             {/*edit button*/}
-            <Menu.Target>
+            <Popover.Target>
               <Badge color="grey" variant="light" style={{ cursor: "pointer" }}>
                 <IconPencil
                   size={16}
                   style={{ transform: "translateY(2px)" }}
                 />
               </Badge>
-            </Menu.Target>
+            </Popover.Target>
             {/*Actions for the Tag Picker*/}
-            <Menu.Dropdown
+            <Popover.Dropdown
               style={{
                 padding: "10px",
                 marginLeft: "-25px",
                 marginTop: "2px",
-                maxHeight: "230px",
-                overflowY: "auto",
-                overflowX: "hidden",
+                width: "300px",
               }}
             >
               <TagPicker
@@ -325,8 +323,8 @@ export function Overview() {
                   setFetchedData(updatedFetchedData);
                 }}
               />
-            </Menu.Dropdown>
-          </Menu>
+            </Popover.Dropdown>
+          </Popover>
         </Group>
       </Table.Td>
     </Table.Tr>

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -13,6 +13,7 @@ import {
   Badge,
   Popover,
 } from "@mantine/core";
+import { isValidHexColor } from "~/utilities/TagPicker";
 import {
   IconSelector,
   IconChevronDown,
@@ -289,7 +290,9 @@ export function Overview() {
                 }}
                 onChangeTagColor={(tagName, newColor) => {
                   // update tag color in backend
-                  changeTagColor(tagName, newColor);
+                  isValidHexColor(newColor)
+                    ? changeTagColor(tagName, newColor)
+                    : null;
 
                   // update tags in frontend
                   const updatedRenderedData = renderedData.map((missionRow) => {

--- a/frontend/app/utilities/TagList.tsx
+++ b/frontend/app/utilities/TagList.tsx
@@ -1,7 +1,8 @@
 import { Badge, Group, Popover } from "@mantine/core";
 import { IconPencil } from "@tabler/icons-react";
 import { Tag } from "~/data";
-import { TagPicker } from "./TagPicker";
+import { TagPicker, isValidHexColor } from "./TagPicker";
+
 import {
   addTagToMission,
   changeTagColor,
@@ -56,7 +57,9 @@ export function RenderTagsDetailView({
             }}
             onChangeTagColor={(tagName, newColor) => {
               // update tag color in backend
-              changeTagColor(tagName, newColor);
+              isValidHexColor(newColor)
+                ? changeTagColor(tagName, newColor)
+                : null;
 
               // update tags in frontend
               setTags((prev) =>

--- a/frontend/app/utilities/TagList.tsx
+++ b/frontend/app/utilities/TagList.tsx
@@ -24,7 +24,7 @@ export function RenderTagsDetailView({
   return (
     <Group gap="xs">
       {/*edit button*/}
-      <Menu>
+      <Menu closeOnClickOutside={false}>
         <Menu.Target>
           <Badge color="grey" variant="light" style={{ cursor: "pointer" }}>
             <IconPencil size={16} style={{ transform: "translateY(2px)" }} />

--- a/frontend/app/utilities/TagList.tsx
+++ b/frontend/app/utilities/TagList.tsx
@@ -1,4 +1,4 @@
-import { Badge, Group, Menu } from "@mantine/core";
+import { Badge, Group, Popover } from "@mantine/core";
 import { IconPencil } from "@tabler/icons-react";
 import { Tag } from "~/data";
 import { TagPicker } from "./TagPicker";
@@ -24,14 +24,16 @@ export function RenderTagsDetailView({
   return (
     <Group gap="xs">
       {/*edit button*/}
-      <Menu closeOnClickOutside={false}>
-        <Menu.Target>
+      <Popover>
+        <Popover.Target>
           <Badge color="grey" variant="light" style={{ cursor: "pointer" }}>
             <IconPencil size={16} style={{ transform: "translateY(2px)" }} />
           </Badge>
-        </Menu.Target>
+        </Popover.Target>
         {/*Actions for the Tag Picker*/}
-        <Menu.Dropdown style={{ padding: "10px", marginLeft: "75px" }}>
+        <Popover.Dropdown
+          style={{ padding: "10px", marginLeft: "75px", width: "300px" }}
+        >
           <TagPicker
             tags={tags}
             onAddNewTag={(tagName, tagColor) => {
@@ -67,8 +69,8 @@ export function RenderTagsDetailView({
               );
             }}
           />
-        </Menu.Dropdown>
-      </Menu>
+        </Popover.Dropdown>
+      </Popover>
       {/*list of tags*/}
       {tags.map((item) => (
         <Badge

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -1,11 +1,10 @@
-import React, { cloneElement, useState } from "react";
+import React, { useState } from "react";
 import {
   Badge,
   Button,
   Group,
   TextInput,
   Stack,
-  ColorPicker,
   ColorInput,
   Popover,
 } from "@mantine/core";
@@ -19,6 +18,12 @@ interface TagPickerProps {
   onChangeTagColor: (tagName: string, newColor: string) => void;
 }
 
+export function isValidHexColor(input: string): boolean {
+  // checks if input is a valid hex color with 3 or 6 characters
+  const hexRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+  return hexRegex.test(input);
+}
+
 export const TagPicker: React.FC<TagPickerProps> = ({
   tags,
   onAddNewTag,
@@ -27,7 +32,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
 }) => {
   const [newTagName, setNewTagName] = useState("");
   const [selectedColor, setSelectedColor] = useState("");
-  const [newTagNameError, setNewTagNameError] = useState<string | null>(null);
+  const [newTagError, setNewTagError] = useState<string | null>(null);
   const swatches = [
     "#390099",
     "#2c7da0",
@@ -39,30 +44,30 @@ export const TagPicker: React.FC<TagPickerProps> = ({
     "#80b918",
   ];
 
-  function isValidHexColor(input: string): boolean {
-    // Der reguläre Ausdruck prüft, ob der Input entweder ein 3-stelliger (#RGB) oder 6-stelliger (#RRGGBB) Hex-Code ist
-    const hexRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{4})$/;
-    return hexRegex.test(input);
-  }
-
   const handleAddTag = () => {
     if (newTagName) {
       // check if tag already exists
       if (tags.find((tag) => tag.name === newTagName)) {
-        setNewTagNameError("This tag already exists");
+        setNewTagError("This tag already exists");
         setNewTagName("");
         return;
       }
       // check if tag name is too long (max 42 characters)
       if (newTagName.length > 42) {
-        setNewTagNameError("This tag name is too long");
+        setNewTagError("This tag name is too long");
         setNewTagName("");
+        return;
+      }
+
+      // check if color is valid
+      if (!isValidHexColor(selectedColor)) {
+        setNewTagError("Invalid color");
         return;
       }
       onAddNewTag(newTagName, selectedColor);
       setNewTagName("");
       setSelectedColor("");
-      setNewTagNameError(null);
+      setNewTagError(null);
     }
   };
 
@@ -74,7 +79,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
           value={newTagName}
           onChange={(e) => setNewTagName(e.target.value)}
           placeholder="Add a new tag"
-          error={newTagNameError}
+          error={newTagError}
           onKeyDown={(e) => {
             e.key === "Enter" && handleAddTag();
           }}
@@ -145,7 +150,9 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                   <ColorInput
                     size="sm"
                     value={tag.color}
-                    onChange={(color) => onChangeTagColor(tag.name, color)}
+                    onChange={(color) => {
+                      onChangeTagColor(tag.name, color);
+                    }}
                     popoverProps={{ withinPortal: false }}
                     swatches={swatches}
                     swatchesPerRow={8}

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -7,6 +7,7 @@ import {
   TextInput,
   Stack,
   ColorPicker,
+  ColorInput,
 } from "@mantine/core";
 import { IconTrash, IconPlus, IconPalette } from "@tabler/icons-react";
 import { Tag } from "~/data";
@@ -26,7 +27,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
 }) => {
   const [newTagName, setNewTagName] = useState("");
   const [selectedColor, setSelectedColor] = useState("#390099");
-  const [error, setError] = useState<string | null>(null);
+  const [newTagNameError, setNewTagNameError] = useState<string | null>(null);
+  const [newTagColorError, setNewTagColorError] = useState<string | null>(null);
   const swatches = [
     "#390099",
     "#2c7da0",
@@ -38,35 +40,46 @@ export const TagPicker: React.FC<TagPickerProps> = ({
     "#80b918",
   ];
 
+  function isHexCode(str: string) {
+    const hexRegex = /^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+    return hexRegex.test(str);
+  }
+
   const handleAddTag = () => {
     if (newTagName) {
       // check if tag already exists
       if (tags.find((tag) => tag.name === newTagName)) {
-        setError("This tag already exists");
+        setNewTagNameError("This tag already exists");
         setNewTagName("");
         return;
       }
       // check if tag name is too long (max 42 characters)
       if (newTagName.length > 42) {
-        setError("This tag name is too long");
+        setNewTagNameError("This tag name is too long");
         setNewTagName("");
+        return;
+      }
+      // check if color is valid
+      if (!isHexCode(selectedColor)) {
+        setNewTagColorError("Color input is not a valid hex code");
+        setSelectedColor("#390099");
         return;
       }
       onAddNewTag(newTagName, selectedColor);
       setNewTagName("");
-      setError(null);
+      setNewTagNameError(null);
     }
   };
 
   return (
     <Stack gap={4}>
-      <Group gap="xs" style={{ display: "flex", marginBottom: "2px" }}>
+      <Group gap="xs" style={{ display: "flex" }}>
         {/*input for new tag name*/}
         <TextInput
           value={newTagName}
           onChange={(e) => setNewTagName(e.target.value)}
           placeholder="Add a new tag"
-          error={error}
+          error={newTagNameError}
           onKeyDown={(e) => {
             e.key === "Enter" && handleAddTag();
           }}
@@ -81,24 +94,28 @@ export const TagPicker: React.FC<TagPickerProps> = ({
           <IconPlus size={16} />
         </Button>
       </Group>
-      {/*custom color picker*/}
-      <div style={{ display: "flex", gap: "8px" }}>
-        {swatches.map((swatch) => (
-          <div
-            key={swatch}
-            style={{
-              width: "30px",
-              height: "30px",
-              backgroundColor: swatch,
-              border:
-                selectedColor === swatch ? "3px solid black" : "1px solid gray",
-              borderRadius: "4px",
-              cursor: "pointer",
-            }}
-            onClick={() => setSelectedColor(swatch)}
-          />
-        ))}
-      </div>
+
+      {/*color input*/}
+      <ColorInput
+        placeholder="placeholder"
+        value={selectedColor}
+        onChange={setSelectedColor}
+        style={{ marginBottom: -7, marginTop: 1 }}
+        error={newTagColorError}
+        onKeyDown={(e) => {
+          e.key === "Enter" && handleAddTag();
+        }}
+      />
+
+      {/*color picker*/}
+      <ColorPicker
+        onChange={setSelectedColor}
+        value={selectedColor}
+        swatchesPerRow={8}
+        swatches={swatches}
+        withPicker={false}
+        style={{ width: "100%" }}
+      />
 
       {/*list of tags*/}
       {tags.map((tag) => (
@@ -117,7 +134,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
               shadow="md"
               styles={{
                 dropdown: {
-                  padding: 4,
+                  padding: 6,
                 },
               }}
             >
@@ -132,13 +149,23 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                 </Button>
               </Menu.Target>
               <Menu.Dropdown>
-                <ColorPicker
-                  size="xs"
-                  onChange={(color) => onChangeTagColor(tag.name, color)}
-                  withPicker={false}
-                  swatchesPerRow={4}
-                  swatches={swatches}
-                />
+                <Stack gap={0}>
+                  <ColorInput
+                    size="sm"
+                    value={tag.color}
+                    onChange={(color) => onChangeTagColor(tag.name, color)}
+                    error={newTagColorError}
+                    style={{ width: "179px", marginBottom: -3, marginTop: 2 }}
+                  />
+                  <ColorPicker
+                    size="xs"
+                    onChange={(color) => onChangeTagColor(tag.name, color)}
+                    withPicker={false}
+                    swatchesPerRow={4}
+                    swatches={swatches}
+                    style={{ marginBottom: -1 }}
+                  />
+                </Stack>
               </Menu.Dropdown>
             </Menu>
 

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -110,6 +110,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         popoverProps={{
           withinPortal: false,
         }}
+        withEyeDropper={false}
       />
 
       {/*list of tags*/}
@@ -156,6 +157,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                     popoverProps={{ withinPortal: false }}
                     swatches={swatches}
                     swatchesPerRow={8}
+                    withEyeDropper={false}
                   />
                 </Stack>
               </Popover.Dropdown>


### PR DESCRIPTION
resolves #128 

# Changes
- I replaced the Menu Components in the TagPicker with Popover because this makes it easier to keep the sub menus open. Now Sub menus stay open when clicking on them
- I replaced the color Picker that only had 8 colors with a custom color Input field where you can put any color in hex code
![grafik](https://github.com/user-attachments/assets/090bf51d-69e7-44dd-b43e-13dbff8af12d)
It also gets checked if the hex input is a correct color. If not. There is an error message.