### PR TITLE
Tag picker edit tag menu

### DIFF
--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -370,44 +370,31 @@ export function Overview() {
                   setFetchedData(fetchedData.map(updateMissionTags));
                   setRenderedData(renderedData.map(updateMissionTags));
                 }}
-                onChangeTagName={async (oldName, newName) => {
+                onEditTag={async (tagName, newName, newColor) => {
                   // update tag name in backend
-                  await changeTagName(oldName, newName);
-
-                  // update tag name in frontend
-                  const updateTagName = (mission: RenderedMission) => ({
-                    ...mission,
-                    tags: mission.tags.map((tag) =>
-                      tag.name === oldName ? { ...tag, name: newName } : tag,
-                    ),
-                  });
-                  setAllTags(
-                    allTags.map((tag) =>
-                      tag.name === oldName ? { ...tag, name: newName } : tag,
-                    ),
-                  );
-                  setFetchedData(fetchedData.map(updateTagName));
-                  setRenderedData(renderedData.map(updateTagName));
-                }}
-                onChangeTagColor={async (tagName, newColor) => {
+                  await changeTagName(tagName, newName);
                   // update tag color in backend
                   if (!isValidHexColor(newColor)) return;
-                  await changeTagColor(tagName, newColor);
+                  await changeTagColor(newName, newColor);
 
-                  // Update tag color in frontend
-                  const updateTagColor = (mission: RenderedMission) => ({
+                  // update tag in frontend
+                  const updateTag = (mission: RenderedMission) => ({
                     ...mission,
                     tags: mission.tags.map((tag) =>
-                      tag.name === tagName ? { ...tag, color: newColor } : tag,
+                      tag.name === tagName
+                        ? { name: newName, color: newColor }
+                        : tag,
                     ),
                   });
                   setAllTags(
                     allTags.map((tag) =>
-                      tag.name === tagName ? { ...tag, color: newColor } : tag,
+                      tag.name === tagName
+                        ? { name: newName, color: newColor }
+                        : tag,
                     ),
                   );
-                  setFetchedData(fetchedData.map(updateTagColor));
-                  setRenderedData(renderedData.map(updateTagColor));
+                  setFetchedData(fetchedData.map(updateTag));
+                  setRenderedData(renderedData.map(updateTag));
                 }}
                 onDeleteAllTags={async () => {
                   // update tags in backend

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -24,6 +24,7 @@ import classes from "./Overview.module.css";
 import { MissionData, RenderedMission, Tag } from "~/data";
 import {
   addTagToMission,
+  changeTagName,
   changeTagColor,
   removeTagFromMission,
   createTag,
@@ -368,6 +369,25 @@ export function Overview() {
                       : mission;
                   setFetchedData(fetchedData.map(updateMissionTags));
                   setRenderedData(renderedData.map(updateMissionTags));
+                }}
+                onChangeTagName={async (oldName, newName) => {
+                  // update tag name in backend
+                  await changeTagName(oldName, newName);
+
+                  // update tag name in frontend
+                  const updateTagName = (mission: RenderedMission) => ({
+                    ...mission,
+                    tags: mission.tags.map((tag) =>
+                      tag.name === oldName ? { ...tag, name: newName } : tag,
+                    ),
+                  });
+                  setAllTags(
+                    allTags.map((tag) =>
+                      tag.name === oldName ? { ...tag, name: newName } : tag,
+                    ),
+                  );
+                  setFetchedData(fetchedData.map(updateTagName));
+                  setRenderedData(renderedData.map(updateTagName));
                 }}
                 onChangeTagColor={async (tagName, newColor) => {
                   // update tag color in backend

--- a/frontend/app/utilities/TagList.tsx
+++ b/frontend/app/utilities/TagList.tsx
@@ -5,6 +5,7 @@ import { TagPicker, isValidHexColor } from "./TagPicker";
 
 import {
   addTagToMission,
+  changeTagName,
   changeTagColor,
   createTag,
   deleteTag,
@@ -72,6 +73,26 @@ export function RenderTagsDetailView({
               }
               // update tags in frontend
               setTags(tags.filter((tag) => tag.name !== tagName));
+            }}
+            onChangeTagName={async (oldTagName, newTagName) => {
+              // update tag name in backend
+              await changeTagName(oldTagName, newTagName);
+
+              // update tags in frontend
+              setTags((prev) =>
+                prev.map((tag) =>
+                  tag.name === oldTagName
+                    ? { name: newTagName, color: tag.color }
+                    : tag,
+                ),
+              );
+              setAllTags((prev) =>
+                prev.map((tag) =>
+                  tag.name === oldTagName
+                    ? { name: newTagName, color: tag.color }
+                    : tag,
+                ),
+              );
             }}
             onChangeTagColor={async (tagName, newColor) => {
               // update tag color in backend

--- a/frontend/app/utilities/TagList.tsx
+++ b/frontend/app/utilities/TagList.tsx
@@ -74,43 +74,23 @@ export function RenderTagsDetailView({
               // update tags in frontend
               setTags(tags.filter((tag) => tag.name !== tagName));
             }}
-            onChangeTagName={async (oldTagName, newTagName) => {
-              // update tag name in backend
-              await changeTagName(oldTagName, newTagName);
-
-              // update tags in frontend
-              setTags((prev) =>
-                prev.map((tag) =>
-                  tag.name === oldTagName
-                    ? { name: newTagName, color: tag.color }
-                    : tag,
-                ),
-              );
-              setAllTags((prev) =>
-                prev.map((tag) =>
-                  tag.name === oldTagName
-                    ? { name: newTagName, color: tag.color }
-                    : tag,
-                ),
-              );
-            }}
-            onChangeTagColor={async (tagName, newColor) => {
-              // update tag color in backend
-              if (!isValidHexColor(newColor)) return;
-              await changeTagColor(tagName, newColor);
+            onEditTag={async (tagName, newName, newColor) => {
+              // update tag in backend
+              await changeTagName(tagName, newName);
+              await changeTagColor(newName, newColor);
 
               // update tags in frontend
               setTags((prev) =>
                 prev.map((tag) =>
                   tag.name === tagName
-                    ? { name: tagName, color: newColor }
+                    ? { name: newName, color: newColor }
                     : tag,
                 ),
               );
               setAllTags((prev) =>
                 prev.map((tag) =>
                   tag.name === tagName
-                    ? { name: tagName, color: newColor }
+                    ? { name: newName, color: newColor }
                     : tag,
                 ),
               );

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -88,14 +88,6 @@ export const TagPicker: React.FC<TagPickerProps> = ({
       return;
     }
 
-    // check if the new tag name is already in existing tags
-    if (otherExistingTags.find((tag) => tag.name === newTagName)) {
-      setChangeTagNameError(
-        "Please add this tag with the 'Add existing tags' button",
-      );
-      return;
-    }
-
     // check if color is valid
     if (!isValidHexColor(newTagColor)) {
       setChangeColorError("Invalid color");

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Badge,
   Button,
@@ -8,7 +8,7 @@ import {
   ColorInput,
   Popover,
 } from "@mantine/core";
-import { IconTrash, IconPlus, IconPalette } from "@tabler/icons-react";
+import { IconTrash, IconPlus } from "@tabler/icons-react";
 import { Tag } from "~/data";
 import { useClickOutside } from "@mantine/hooks";
 
@@ -39,7 +39,6 @@ export const TagPicker: React.FC<TagPickerProps> = ({
 }) => {
   const [newTagName, setNewTagName] = useState("");
   const [selectedColor, setSelectedColor] = useState("");
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const [changedTagName, setChangedTagName] = useState<string>("");
   const [newColor, setNewColor] = useState<string>("");
   const [changeTagNameError, setChangeTagNameError] = useState<string | null>(
@@ -302,7 +301,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
             <Button
               color="blue"
               size="xs"
-              style={{ textTransform: "none", cursor: "pointer", width: "48%" }}
+              style={{ textTransform: "none", width: "48%" }}
+              disabled={otherExistingTags.length === 0}
             >
               Add existing tags
             </Button>
@@ -350,7 +350,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         <Button
           color="red"
           size="xs"
-          style={{ textTransform: "none", cursor: "pointer", width: "48%" }}
+          style={{ textTransform: "none", width: "48%" }}
+          disabled={tags.length === 0}
           onClick={() => {
             if (
               window.confirm(

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mantine/core";
 import { IconTrash, IconPlus, IconPalette } from "@tabler/icons-react";
 import { Tag } from "~/data";
+import { useClickOutside } from "@mantine/hooks";
 
 interface TagPickerProps {
   tags: Tag[];
@@ -48,6 +49,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
   const [newTagNameError, setNewTagNameError] = useState<string | null>(null);
   const [newTagColorError, setNewTagColorError] = useState<string | null>(null);
   const [otherExistingTags, setOtherExistingTags] = useState<Tag[]>([]);
+  const [editedTagName, setEditedTagName] = useState<string>("");
+  const ref = useClickOutside(() => setEditedTagName(""));
   const swatches = [
     "#ff5400",
     "#ffbd00",
@@ -103,6 +106,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
     // reset errors and update tag
     setChangeTagNameError("");
     setChangeColorError("");
+    setEditedTagName("");
     onEditTag(tagName, newTagName, newTagColor);
   };
 
@@ -206,25 +210,23 @@ export const TagPicker: React.FC<TagPickerProps> = ({
               }}
               width={120}
               withinPortal={false}
-              onOpen={() => {
-                setChangedTagName(tag.name);
-                setNewColor(tag.color);
-              }}
-              onClose={() => {
-                setChangeTagNameError("");
-                setChangeColorError("");
-              }}
+              opened={editedTagName === tag.name}
             >
               <Popover.Target>
                 <Badge
                   color={tag.color}
                   variant="light"
                   style={{ textTransform: "none", cursor: "pointer" }}
+                  onClick={() => {
+                    setEditedTagName(tag.name);
+                    setChangedTagName(tag.name);
+                    setNewColor(tag.color);
+                  }}
                 >
                   {tag.name}
                 </Badge>
               </Popover.Target>
-              <Popover.Dropdown style={{ padding: 6 }}>
+              <Popover.Dropdown style={{ padding: 6 }} ref={ref}>
                 {/* edit tag menu */}
                 <Stack gap={6}>
                   {/* name change */}
@@ -250,8 +252,9 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                       setChangeColorError("");
                     }}
                     onKeyDown={(e) => {
-                      e.key === "Enter" &&
+                      if (e.key === "Enter") {
                         handleTagEdit(tag.name, changedTagName, newColor);
+                      }
                     }}
                     popoverProps={{ withinPortal: false }}
                     swatches={swatches}

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -194,7 +194,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
       {tags.map((tag) => (
         <Group key={tag.name} gap="apart">
           <Group gap="xs">
-            {/* Button to change tag color */}
+            {/* popover for tag edit */}
             <Popover
               withArrow
               shadow="md"

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -262,6 +262,19 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                     withEyeDropper={false}
                     error={changeColorError}
                   />
+                  {/* save button */}
+                  <Button
+                    size="xs"
+                    color="blue"
+                    onClick={() =>
+                      handleTagEdit(tag.name, changedTagName, newColor)
+                    }
+                    disabled={
+                      tag.name === changedTagName && tag.color === newColor
+                    }
+                  >
+                    Save
+                  </Button>
                 </Stack>
               </Popover.Dropdown>
             </Popover>
@@ -287,7 +300,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         <Popover withArrow withinPortal={false}>
           <Popover.Target>
             <Button
-              color="#228be6"
+              color="blue"
               size="xs"
               style={{ textTransform: "none", cursor: "pointer", width: "48%" }}
             >

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -230,7 +230,9 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                 </Badge>
               </Popover.Target>
               <Popover.Dropdown style={{ padding: 6 }}>
+                {/* edit tag menu */}
                 <Stack gap={6}>
+                  {/* name change */}
                   <TextInput
                     size="sm"
                     value={changedTagName}
@@ -244,6 +246,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                     }}
                     error={changeTagNameError}
                   />
+                  {/* color change */}
                   <ColorInput
                     size="sm"
                     value={newColor}

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -74,7 +74,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
   const handleNameChange = (tagName: string, newTagName: string) => {
     setChangedTagName(newTagName);
     // check if tag name already exists
-    if (tags.find((tag) => tag.name === newTagName)) {
+    if (tags.find((tag) => tag.name === newTagName) && tagName !== newTagName) {
       setChangeTagNameError("This tag name is already in use");
       return;
     }
@@ -153,7 +153,10 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         {/*input for new tag name*/}
         <TextInput
           value={newTagName}
-          onChange={(e) => setNewTagName(e.target.value)}
+          onChange={(e) => {
+            setNewTagName(e.target.value);
+            setNewTagNameError("");
+          }}
           placeholder="Add a new tag"
           error={newTagNameError}
           onKeyDown={(e) => {
@@ -176,7 +179,10 @@ export const TagPicker: React.FC<TagPickerProps> = ({
       <ColorInput
         placeholder="#ffffff"
         value={selectedColor}
-        onChange={setSelectedColor}
+        onChange={(color) => {
+          setSelectedColor(color);
+          setNewTagColorError("");
+        }}
         style={{ marginTop: 3 }}
         onKeyDown={(e) => {
           e.key === "Enter" && handleAddTag();
@@ -209,6 +215,10 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                 setChangedTagName(tag.name);
                 setNewColor(tag.color);
               }}
+              onClose={() => {
+                setChangeTagNameError("");
+                setChangeColorError("");
+              }}
             >
               <Popover.Target>
                 <Badge
@@ -224,7 +234,10 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                   <TextInput
                     size="sm"
                     value={changedTagName}
-                    onChange={(e) => setChangedTagName(e.target.value)}
+                    onChange={(e) => (
+                      setChangedTagName(e.target.value),
+                      setChangeTagNameError("")
+                    )}
                     onKeyDown={(e) => {
                       e.key === "Enter" &&
                         handleNameChange(tag.name, changedTagName);

--- a/frontend/app/utilities/fetchapi.test.ts
+++ b/frontend/app/utilities/fetchapi.test.ts
@@ -7,6 +7,7 @@ import {
     getTags,
     addTagToMission,
     removeTagFromMission,
+    changeTagName,
     changeTagColor,
     createTag,
     deleteTag,
@@ -345,6 +346,31 @@ describe("Fetch API Functions", () => {
         {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
+        }
+      );
+    });
+
+    test("changeTagName should change the name of a tag by name", async () => {
+      const mockResponse: Tag = {
+        name: "ImportantTag",
+        color: "#FF0000",
+      };
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          //id: 1,
+          name: "ImportantTag",
+          color: "#FF0000",
+        }),
+      });
+      const result = await changeTagName("ImportantTag", "NewTag");
+      expect(result).toEqual(mockResponse);
+      expect(fetch).toHaveBeenCalledWith(
+        `${FETCH_API_BASE_URL}/tags/ImportantTag`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "NewTag" }),
         }
       );
     });

--- a/frontend/app/utilities/fetchapi.ts
+++ b/frontend/app/utilities/fetchapi.ts
@@ -126,6 +126,28 @@ export const removeTagFromMission = async (missionId: number, tagName: string): 
     }
 };
 
+// change the name of a tag
+export const changeTagName = async (tagName: string, newName: string): Promise<Tag> => {
+    const response = await fetch(`${FETCH_API_BASE_URL}/tags/${encodeURIComponent(encodeURIComponent(tagName))}`, {
+        method: 'PUT',
+        headers: headers,
+        body: JSON.stringify({ name: newName }),
+    });
+    if (!response.ok) {
+        if (response.status === 400) {
+            throw new Error('Invalid data. Ensure the tag name is correct.');
+        } else if (response.status === 404) {
+            throw new Error(`Tag with name "${tagName}" not found.`);
+        }
+        throw new Error('Failed to change tag name');
+    }
+    const data = await response.json();
+    return {
+        name: data.name,
+        color: data.color,
+    }
+};
+
 // Change the color of a tag
 export const changeTagColor = async (tagName: string, newColor: string): Promise<Tag> => {
     const response = await fetch(`${FETCH_API_BASE_URL}/tags/${encodeURIComponent(encodeURIComponent(tagName))}`, {


### PR DESCRIPTION
resolves #162 

# Changes
This PR implements a little menu in the tag picker to change the name and color of an existing tag. This menu replaces the little color palette icon that was used to change the color before.
The new edit tag menu can be opened by clicking on a tag that gets listed in the tag picker
![grafik](https://github.com/user-attachments/assets/70f56847-2e93-4413-8bfe-9c9afdf7cb2a)
You can change the name and the color there. Once something was changed, the 'Save' button can be clicked.
![grafik](https://github.com/user-attachments/assets/a54efa24-99f5-4d42-8abd-ebf6b727065b)
After clicking the 'Save' button, the changes get saved and the menu closes. Alternatively you can also do that by pressing enter on your keyboard.
There are 3 error cases that get checked once enter or 'Save' was pressed:
- tag name already exists
- tag name is too long
- invaild color

I also disabled the 'Add existing tags' and the 'Remove all tags' buttons if there are no already existing tags or no tags to delete.
![grafik](https://github.com/user-attachments/assets/20cec7f6-9adc-4262-b6b6-29e3a527cda1)

![grafik](https://github.com/user-attachments/assets/bbd46787-3ee0-4f18-b680-bc248885e404)




