### PR TITLE
syncfolder (delete non existing missions)

### DIFF
--- a/backend/cli_commands/SyncFolderCommand.py
+++ b/backend/cli_commands/SyncFolderCommand.py
@@ -14,16 +14,12 @@ class SyncFolderCommand(Command):
             self.name, help="adds all missions from folder"
         )
         sync_parser.add_argument("--path", required=True, help="Filepath")
-        sync_parser.add_argument("--location", required=False, help="location")
-        sync_parser.add_argument(
-            "--notes", required=False, help="other mission details"
-        )
 
     def command(self, args):
-        sync_folder(args.path, args.location, args.notes)
+        sync_folder(args.path)
 
 
-def sync_folder(folder_path, location=None, notes=None):
+def sync_folder(folder_path):
     """
     Syncs all Missions from a folder:
     - Adds missions from folders in the filesystem that are not in the database.
@@ -47,15 +43,13 @@ def sync_folder(folder_path, location=None, notes=None):
         # Add missions for folders not yet in the database
         for folder in fs_mission_set - db_mission_set:
             folder_path_full = os.path.join(folder_path, folder)
-            add_mission_from_folder(folder_path_full, location, notes)
+            add_mission_from_folder(folder_path_full, None, None)
 
         # Delete missions from the database not found in the filesystem
         for mission_str in db_mission_set - fs_mission_set:
             date_str, name = mission_str.split("_", 1)
             mission_date = datetime.strptime(date_str, "%Y.%m.%d").date()
-            mission_to_delete = Mission.objects.filter(
-                name=name, date=mission_date
-            ).first()
+            mission_to_delete = Mission.objects.filter(name=name, date=mission_date)[0]
             if mission_to_delete:
                 try:
                     mission_to_delete.delete()

--- a/backend/cli_commands/SyncFolderCommand.py
+++ b/backend/cli_commands/SyncFolderCommand.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 import os
 import logging
 from .Command import Command
 from .AddFolderCommand import add_mission_from_folder
+from restapi.models import Mission
 
 
 class SyncFolderCommand(Command):
@@ -23,12 +25,44 @@ class SyncFolderCommand(Command):
 
 def sync_folder(folder_path, location=None, notes=None):
     """
-    Adds all Missions from a folder wich are not yet in the DB
+    Syncs all Missions from a folder:
+    - Adds missions from folders in the filesystem that are not in the database.
+    - Deletes missions from the database that are not in the filesystem.
     """
     if os.path.isdir(folder_path):
-        for item in os.listdir(folder_path):
-            item_path = os.path.join(folder_path, item)
-            if os.path.isdir(item_path):
-                add_mission_from_folder(item_path, location, notes)
+        # Get all existing missions in the database
+        db_missions = Mission.objects.filter()
+        db_mission_set = set(
+            f"{mission.date.strftime('%Y.%m.%d')}_{mission.name}"
+            for mission in db_missions
+        )
+
+        # Get all folder names in the filesystem
+        fs_mission_set = set(
+            folder
+            for folder in os.listdir(folder_path)
+            if os.path.isdir(os.path.join(folder_path, folder))
+        )
+
+        # Add missions for folders not yet in the database
+        for folder in fs_mission_set - db_mission_set:
+            folder_path_full = os.path.join(folder_path, folder)
+            add_mission_from_folder(folder_path_full, location, notes)
+
+        # Delete missions from the database not found in the filesystem
+        for mission_str in db_mission_set - fs_mission_set:
+            date_str, name = mission_str.split("_", 1)
+            mission_date = datetime.strptime(date_str, "%Y.%m.%d").date()
+            mission_to_delete = Mission.objects.filter(
+                name=name, date=mission_date
+            ).first()
+            if mission_to_delete:
+                try:
+                    mission_to_delete.delete()
+                    logging.info(
+                        f"Deleted mission '{name}' from database as it's no longer in the filesystem."
+                    )
+                except Exception as e:
+                    logging.error(f"Error deleting mission '{name}': {e}")
     else:
-        logging.error("invalid path")
+        logging.error("Invalid path")

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -155,7 +155,7 @@ Arguments:
 - `--notes` (optional) additional information
 
 ### `cli.py syncfolder`
-adds all missions from a folder not currently in the database
+adds all missions from a folder not currently in the database and deletes all missions from the database that are not in the folder
 
 Arguments:
 - `--path` path to mission folder containing the missionfolders 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -158,13 +158,11 @@ Arguments:
 adds all missions from a folder not currently in the database and deletes all missions from the database that are not in the folder
 
 Arguments:
-- `--path` path to mission folder containing the missionfolders 
-- `--location` (optional) the location where the mission took place
-- `--notes` (optional) additional information
+- `--path` path to mission folder containing the missionfolders
 
 Example:
 ```
-./cli.py syncfolder --path "your/path/name" --location "location(optional)" --notes "notes(optional)"
+./cli.py syncfolder --path "your/path/name"
 ```
 
 ### `cli.py tag`


### PR DESCRIPTION
# Changes
A small change that makes the syncfolder command also delete missions that do not exist in the filesystem anymore.

This does not resolve Issue #108 yet because files do not get stored in the database yet. So they can not be synchronised.

In development I was wondering why it is possible to use the arguments "location" and "notes" with the syncfolder command since I don't see a use for these arguments in the syncfolder command. So I removed them