### PR TITLE
Fix bug when robot name is null

### DIFF
--- a/frontend/app/pages/details/DetailsView.tsx
+++ b/frontend/app/pages/details/DetailsView.tsx
@@ -17,6 +17,9 @@ function formatRobotNames(robotNames: string[] | undefined | null): string {
   // Create a Set to track normalized names and filter duplicates
   const seen = new Set<string>();
   const uniqueRobots = robotNames.filter((name) => {
+    if (!name) {
+      return false;
+    }
     const normalizedName = name.toLowerCase();
     if (seen.has(normalizedName)) {
       return false;
@@ -55,7 +58,9 @@ const DetailsView: React.FC<DetailsViewProps> = ({
   return (
     <AbstractPage
       headline={`${missionData.name}${location ? `, ${location}` : ""}${
-        detailViewData?.robots ? ` with ${formatRobotNames(detailViewData.robots)}` : ""
+        detailViewData?.robots
+          ? ` with ${formatRobotNames(detailViewData.robots)}`
+          : ""
       }`}
     >
       {/* Main content */}


### PR DESCRIPTION
There was a bug in the frontend that happened when the robot name is not included in a file in the backend and became `null` in the frontend.
This resulted in the following error messages when opening the detail view:
In production:
![grafik](https://github.com/user-attachments/assets/36063371-1ef7-4228-a907-afd49e384cdd)
In development:
![grafik](https://github.com/user-attachments/assets/a8497b7c-bd1c-4d38-ba5e-bd79f98f9e86)

This fixes that bug.