### PR TITLE
Include csrf token in X-CSRFToken header

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -32,7 +32,11 @@ SECRET_KEY = env("SECRET_KEY")
 DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", ".fly.dev"]
-CSRF_TRUSTED_ORIGINS = ["https://*.fly.dev"]
+CSRF_TRUSTED_ORIGINS = [
+    "https://*.fly.dev",
+    "http://localhost:3000",
+    "http://localhost:5173",
+]
 
 CSRF_COOKIE_HTTPONLY = False
 


### PR DESCRIPTION
Because of SessionAuthentication it is required to include the csrftoken in the X-CSRFToken header field in the fetch requests to the backend.\
This was not discovered because django doesn't enforce this on GET requests but all others.\
This caused that tags couldn't be created or added to a mission.

I replaced the `header` constant with a function `getHeader`() which retrieves the csrftoken from `document.cookie` and sets the `X-CSRFToken` header.

## How to test
Adding and creating tags should work again.