### PR TITLE
save metadata on sync command

### DIFF
--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -16,7 +16,7 @@ class AddFolderCommand(Command):
         ### Parameters
         subparser: subparser to which this subcommand belongs to
         """
-        folder_parser = subparser.add_parser(self.name, help="adds details from folder")
+        folder_parser = subparser.add_parser(self.name, help="adds mission from folder")
         folder_parser.add_argument("--path", required=True, help="Filepath")
         folder_parser.add_argument("--location", required=False, help="location")
         folder_parser.add_argument(

--- a/backend/cli_commands/DeleteFolderCommand.py
+++ b/backend/cli_commands/DeleteFolderCommand.py
@@ -15,7 +15,7 @@ class DeleteFolderCommand(Command):
         subparser: subparser to which this subcommand belongs to
         """
         folder_parser = subparser.add_parser(
-            self.name, help="deletes mission details from folder"
+            self.name, help="deletes mission from database based on folder path"
         )
         folder_parser.add_argument("--path", required=True, help="Filepath")
 

--- a/backend/cli_commands/DeleteFolderCommand.py
+++ b/backend/cli_commands/DeleteFolderCommand.py
@@ -1,0 +1,78 @@
+import os
+import logging
+from datetime import datetime
+from .Command import Command
+from restapi.models import Mission, Mission_files
+
+
+class DeleteFolderCommand(Command):
+    name = "deletefolder"
+
+    def parser_setup(self, subparser):
+        """
+        Parser setup for deletefolder subcommand
+        ### Parameters
+        subparser: subparser to which this subcommand belongs to
+        """
+        folder_parser = subparser.add_parser(
+            self.name, help="deletes mission details from folder"
+        )
+        folder_parser.add_argument("--path", required=True, help="Filepath")
+
+    def command(self, args):
+        delete_mission_from_folder(args.path)
+
+
+def delete_mission_from_folder(folder_path):
+    """
+    Delete mission and related data from DB based on folder path
+    ### Parameters
+    folder_path: path to a folder without trailing /\\
+    """
+    folder_name = os.path.basename(folder_path)
+    mission_date, name = extract_info_from_folder(folder_name)
+
+    if mission_date and name:
+        try:
+            # find mission
+            mission = Mission.objects.get(name=name, date=mission_date)
+
+            # find related files and delete them
+            mission_files = Mission_files.objects.filter(mission=mission)
+            for mission_file in mission_files:
+                mission_file.file.delete()
+
+            # delete mission
+            mission.delete()
+
+            logging.info(
+                f"Mission '{name}' from folder '{folder_name}' and corresponding files deleted from the database."
+            )
+        except Mission.DoesNotExist:
+            logging.warning(
+                f"No mission found for name '{name}' and date '{mission_date}'."
+            )
+        except Exception as e:
+            logging.error(f"Error deleting mission: {e}")
+    else:
+        logging.warning("Skipping folder due to naming issues.")
+
+
+def extract_info_from_folder(folder_name):
+    """
+    Extract date and name from folder name
+    ### Parameters
+    folder_name: basename of folder in format YYYY.MM.DD_missionname
+    ### Returns
+    date: date object of extracted date
+    name: extracted mission name
+    """
+    try:
+        date_str, name = folder_name.split("_", 1)
+        mission_date = datetime.strptime(date_str, "%Y.%m.%d").date()
+        return mission_date, name
+    except ValueError:
+        logging.error(
+            f"Folder name '{folder_name}' does not match the expected format (YYYY.MM.DD_missionname)."
+        )
+        return None, None

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 import logging
 from django.core.files.storage import DefaultStorage
 from .Command import Command
 from .AddFolderCommand import add_mission_from_folder
+from .DeleteFolderCommand import delete_mission_from_folder
 from restapi.models import Mission, Mission_tags, Tag
 import json
 
@@ -40,18 +40,8 @@ def sync_folder():
         add_mission_from_folder(folder, None, None)
 
     # Delete missions from the database not found in the filesystem
-    for mission_str in db_mission_set - fs_mission_set:
-        date_str, name = mission_str.split("_", 1)
-        mission_date = datetime.strptime(date_str, "%Y.%m.%d").date()
-        mission_to_delete = Mission.objects.filter(name=name, date=mission_date)[0]
-        if mission_to_delete:
-            try:
-                mission_to_delete.delete()
-                logging.info(
-                    f"Deleted mission '{name}' from database as it's no longer in the filesystem."
-                )
-            except Exception as e:
-                logging.error(f"Error deleting mission '{name}': {e}")
+    for folder in db_mission_set - fs_mission_set:
+        delete_mission_from_folder(folder)
 
     # find unused tags and delete them
     Tag.objects.filter(mission_tags=None).delete()

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -47,6 +47,9 @@ def sync_folder():
     # find unused tags and delete them
     Tag.objects.filter(mission_tags=None).delete()
 
+    # update db_missions after adding and deleting missions
+    db_missions = Mission.objects.filter()
+
     # save metadata for each mission in the filesystem
     for mission in db_missions:
         tags = Tag.objects.filter(mission_tags__mission=mission)

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -1,9 +1,10 @@
 import logging
 from django.core.files.storage import DefaultStorage
+from restapi.serializer import TagSerializer
 from .Command import Command
 from .AddFolderCommand import add_mission_from_folder
 from .DeleteFolderCommand import delete_mission_from_folder
-from restapi.models import Mission, Mission_tags, Tag
+from restapi.models import Mission, Tag
 import json
 
 
@@ -48,21 +49,17 @@ def sync_folder():
 
     # save metadata for each mission in the filesystem
     for mission in db_missions:
-        tags = Mission_tags.objects.filter(mission=mission)
-        tag_data = []
-        for mission_tag in tags:
-            tag = Tag.objects.get(id=mission_tag.tag_id)
-            tag_data.append({"name": tag.name, "color": tag.color})
+        tags = Tag.objects.filter(mission_tags__mission=mission)
+        tag_serializer = TagSerializer(tags, many=True)
         metadata = {
             "location": mission.location,
             "notes": mission.notes,
-            "tags": tag_data,
+            "tags": tag_serializer.data,
         }
         # save metadata to file inside mission folder
         metadata_file = f"{mission.date.strftime('%Y.%m.%d')}_{mission.name}/{mission.name}_metadata.json"
-        metadata_file_path = storage.path(metadata_file)
-        with open(metadata_file_path, "w") as f:
+        with storage.open(metadata_file, "w") as f:
             json.dump(metadata, f, indent=4)
             logging.info(
-                f"Saved metadata for mission '{mission.name}' to '{metadata_file_path}'"
+                f"Saved metadata for mission '{mission.name}' to the mission folder"
             )

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -51,10 +51,13 @@ def sync_folder():
     for mission in db_missions:
         tags = Tag.objects.filter(mission_tags__mission=mission)
         tag_serializer = TagSerializer(tags, many=True)
+        mission_tags = [
+            {"name": tag["name"], "color": tag["color"]} for tag in tag_serializer.data
+        ]  # remove id field
         metadata = {
             "location": mission.location,
             "notes": mission.notes,
-            "tags": tag_serializer.data,
+            "tags": mission_tags,
         }
         # save metadata to file inside mission folder
         metadata_file = f"{mission.date.strftime('%Y.%m.%d')}_{mission.name}/{mission.name}_metadata.json"

--- a/backend/cli_commands/test_delete_folder.py
+++ b/backend/cli_commands/test_delete_folder.py
@@ -1,0 +1,70 @@
+from django.test import TestCase
+from restapi.models import Mission, File, Mission_files
+from cli_commands.DeleteFolderCommand import delete_mission_from_folder
+from datetime import datetime
+import logging
+
+
+class DeleteFolderCommandTests(TestCase):
+    def setUp(self):
+        # Disable logging
+        self.logger = logging.getLogger()
+        self.logger.disabled = True
+
+        # Create a mission and related files
+        self.mission = Mission.objects.create(
+            name="test_mission",
+            date=datetime.strptime("2024.12.02", "%Y.%m.%d").date(),
+        )
+
+        self.file = File.objects.create(
+            file="2024.12.02_test_mission/test_file.mcap",
+            size=1024,
+            duration=120.0,
+        )
+
+        self.mission_file = Mission_files.objects.create(
+            mission=self.mission, file=self.file, type="test"
+        )
+
+    def tearDown(self):
+        # Re-enable logging
+        self.logger.disabled = False
+
+    def test_delete_mission_from_folder(self):
+        # Verify mission and files exist before deletion
+        self.assertTrue(Mission.objects.filter(name="test_mission").exists())
+        self.assertTrue(
+            File.objects.filter(file="2024.12.02_test_mission/test_file.mcap").exists()
+        )
+        self.assertTrue(Mission_files.objects.filter(mission=self.mission).exists())
+
+        # Call the delete function
+        delete_mission_from_folder("2024.12.02_test_mission")
+
+        # Verify mission and files are deleted
+        self.assertFalse(Mission.objects.filter(name="test_mission").exists())
+        self.assertFalse(
+            File.objects.filter(file="2024.12.02_test_mission/test_file.mcap").exists()
+        )
+        self.assertFalse(Mission_files.objects.filter(mission=self.mission).exists())
+
+    def test_delete_nonexistent_mission(self):
+        logging.getLogger().disabled = False
+        with self.assertLogs(level="WARNING") as log:
+            delete_mission_from_folder("2025.01.01_nonexistent_mission")
+
+            self.assertIn(
+                "WARNING:root:No mission found for name 'nonexistent_mission' and date '2025-01-01'.",
+                log.output,
+            )
+
+    def test_delete_invalid_folder_name(self):
+        logging.getLogger().disabled = False
+        with self.assertLogs(level="WARNING") as log:
+            delete_mission_from_folder("invalid_folder_name")
+
+            self.assertIn(
+                "ERROR:root:Folder name 'invalid_folder_name' does not match the expected format (YYYY.MM.DD_missionname).",
+                log.output,
+            )

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -41,7 +41,7 @@ class FileWithTypeSerializer(serializers.ModelSerializer):
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
-        fields = "__all__"
+        fields = "name", "color"
 
 
 class MissionTagSerializer(serializers.ModelSerializer):

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -41,7 +41,7 @@ class FileWithTypeSerializer(serializers.ModelSerializer):
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
-        fields = "name", "color"
+        fields = "__all__"
 
 
 class MissionTagSerializer(serializers.ModelSerializer):

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -158,6 +158,12 @@ Arguments:
 - `--location` (optional) the location where the mission took place
 - `--notes` (optional) additional information
 
+### `cli.py deletefolder`
+delets a folder from the database
+
+Arguments:
+- `--path` path to mission folder of format `YYYY.MM.DD_mission_name` without trailing /
+
 ### `cli.py sync`
 adds all missions from a folder not currently in the database and deletes all missions from the database that are not in the folder\
 The folder that is searched for mission folders is the root of the Default Storage as configured in [settings.py](../../backend/backend/settings.py)


### PR DESCRIPTION
resolves #109 

# Changes
When running the `sync` command, the metadata (i.e. location, notes, tags) of each mission gets saved as a json file inside the mission folder

currently there is no check if the metadata changed and needs to be saved. This is something for another issue