### PR TITLE
Added robot names to mission table

### DIFF
--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -85,3 +85,10 @@ export const getTotalSize = async (missionId: number): Promise<string> => {
 
   return transformSizes(stringTotal)[0];
 };
+
+// Get all robot names of a mission
+export const getRobotNames = async (missionId: number): Promise<string[]> => {
+  const details = await getDetailsByMission(missionId);
+
+  return details.robots;
+};

--- a/frontend/app/fetchapi/tests/details.test.tsx
+++ b/frontend/app/fetchapi/tests/details.test.tsx
@@ -1,6 +1,6 @@
 import { FETCH_API_BASE_URL } from "~/config";
 import { DetailViewData } from "~/data";
-import { getDetailsByMission, getFormattedDetails, getTotalDuration, getTotalSize } from "../details";
+import { getDetailsByMission, getFormattedDetails, getRobotNames, getTotalDuration, getTotalSize } from "../details";
 
 /*
 How to run the tests:
@@ -177,6 +177,45 @@ describe("Fetch API Functions", () => {
       });
 
       const details = await getTotalSize(1);
+      expect(details).toEqual(expectedResponse);
+      expect(fetch).toHaveBeenCalledWith(
+        `${FETCH_API_BASE_URL}/missions/1/files/`,
+        {
+          method: "GET",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    });
+
+    test("getRobotNames", async () => {
+      const mockResponse = [
+        {
+          file: {
+            file_path: "file1.mcap",
+            robot: "hihi",
+            duration: "60000",
+            size: "1024",
+          },
+        },
+        {
+          file: {
+            file_path: "file2.mcap",
+            robot: "haha",
+            duration: "1200",
+            size: "2621440",
+          },
+        },
+      ];
+
+      const expectedResponse: string[] = ["hihi", "haha"];
+
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const details = await getRobotNames(1);
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,

--- a/frontend/app/pages/details/DetailsView.tsx
+++ b/frontend/app/pages/details/DetailsView.tsx
@@ -5,38 +5,7 @@ import { ShowDatasets } from "./DatasetTable";
 import { DetailViewData, RenderedMission, Tag } from "~/data";
 import AbstractPage from "../AbstractPage";
 import { ShowInformationView } from "./InformationView";
-
-// This functions returns the robot names in the format x, y and z.
-// For duplicate robot names, only the first occurance is used, e.g. x, y, x -> x and y and the camel case is ignored,
-// meaning x, y, X -> x and y.
-function formatRobotNames(robotNames: string[] | undefined | null): string {
-  if (!robotNames) {
-    return "";
-  }
-
-  // Create a Set to track normalized names and filter duplicates
-  const seen = new Set<string>();
-  const uniqueRobots = robotNames.filter((name) => {
-    if (!name) {
-      return false;
-    }
-    const normalizedName = name.toLowerCase();
-    if (seen.has(normalizedName)) {
-      return false;
-    }
-    seen.add(normalizedName);
-    return true;
-  });
-
-  if (uniqueRobots.length === 0) {
-    return "";
-  } else if (uniqueRobots.length === 1) {
-    return uniqueRobots[0];
-  } else {
-    const lastRobot = uniqueRobots.pop();
-    return `${uniqueRobots.join(", ")} and ${lastRobot}`;
-  }
-}
+import { formatRobotNames } from "~/utilities/FormatTransformer";
 
 interface DetailsViewProps {
   missionData: RenderedMission;

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -27,7 +27,8 @@ import { IconPencil } from "@tabler/icons-react";
 import { useNavigate } from "@remix-run/react";
 import { getMissions } from "~/fetchapi/missions";
 import { addTagToMission, changeTagColor, changeTagName, createTag, deleteTag, getMissionsByTag, getTags, getTagsByMission, removeTagFromMission } from "~/fetchapi/tags";
-import { getTotalDuration, getTotalSize } from "~/fetchapi/details";
+import { getDetailsByMission, getRobotNames, getTotalDuration, getTotalSize } from "~/fetchapi/details";
+import { formatRobotNames } from "~/utilities/FormatTransformer";
 
 interface ThProps {
   children: React.ReactNode;
@@ -154,6 +155,10 @@ export function Overview() {
           const totalDuration: string = await getTotalDuration(missions[i].id);
           // Fetch total size for each mission
           const totalSize: string = await getTotalSize(missions[i].id);
+
+          // Fetch robot name for each mission
+          const robots_formatted: string = formatRobotNames(await getRobotNames(missions[i].id), false);
+
           renderedMissions.push({
             id: missions[i].id,
             name: missions[i].name,
@@ -162,7 +167,7 @@ export function Overview() {
             notes: missions[i].notes,
             totalDuration: totalDuration,
             totalSize: totalSize,
-            robot: "Vader",
+            robot: robots_formatted || "",
             tags: tags || [],
           });
         }

--- a/frontend/app/utilities/FormatTransformer.tsx
+++ b/frontend/app/utilities/FormatTransformer.tsx
@@ -38,3 +38,40 @@ export function transformSizes(sizes: string[]): string[] {
     return `${value.toFixed(2)} ${unit}`;
   });
 }
+
+// This functions returns the robot names in the format x, y and z.
+// For duplicate robot names, only the first occurance is used, e.g. x, y, x -> x and y and the camel case is ignored,
+// meaning x, y, X -> x and y.
+export function formatRobotNames(
+  robotNames: string[] | undefined | null,
+  and_separated: boolean = true
+): string {
+  if (!robotNames) {
+    return "";
+  }
+
+  // Create a Set to track normalized names and filter duplicates
+  const seen = new Set<string>();
+  const uniqueRobots = robotNames.filter((name) => {
+    if (!name) {
+      return false;
+    }
+    const normalizedName = name.toLowerCase();
+    if (seen.has(normalizedName)) {
+      return false;
+    }
+    seen.add(normalizedName);
+    return true;
+  });
+
+  if (uniqueRobots.length === 0) {
+    return "";
+  } else if (uniqueRobots.length === 1) {
+    return uniqueRobots[0];
+  } else if (and_separated) {
+    const lastRobot = uniqueRobots.pop();
+    return `${uniqueRobots.join(", ")} and ${lastRobot}`;
+  } else {
+    return uniqueRobots.join(", ");
+  }
+}


### PR DESCRIPTION
Hi,
this PR resolves issue #198 by adding a new function to fetch the robot names in the mission table, and also to display them.
An older PR introduced a new way to display the robot names, this function was extended and moved to utilities. 

To test, do the following:
```
import os
import django

os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
django.setup()

from restapi.models import Mission, File, Mission_files

def add_files_to_mission(mission_id):
    try:
        mission = Mission.objects.get(id=mission_id)
    except Mission.DoesNotExist:
        return f"Mission with ID {mission_id} does not exist."

    files_data = [
        {"file": "geschichte1", "video": "test1.mp4", "robot": "Sheev", "duration": 120, "size": 1024},
        {"file": "geschichte2", "video": "test2.mp4", "robot": "Palpatine", "duration": 180, "size": 2048},
    ]

    for file_data in files_data:
        file = File.objects.create(
            file=file_data["file"],
            video=file_data["video"],
            robot=file_data["robot"],
            duration=file_data["duration"],
            size=file_data["size"]
        )

        Mission_files.objects.create(mission=mission, file=file, type="train")

    return f"Files successfully added to mission ID {mission_id}."

add_files_to_mission(1)`
```
create a new file for this script in /backend and run it, remember to change the missionId. In `backend/media` create dummy files with `touch` named `geschichte1, geschichte2, test1.mp4, test2.mp4`.

After running the script, the robot names should be correctly displayed as "Sheev, Palpatine"

![image](https://github.com/user-attachments/assets/c0a85d85-01c4-4975-8263-5677c97825df)


