### PR TITLE
Fixed bug when changing location and notes field simultaneously

### DIFF
--- a/frontend/app/pages/details/InformationView.tsx
+++ b/frontend/app/pages/details/InformationView.tsx
@@ -110,10 +110,10 @@ export const ShowInformationView: React.FC<ShowInformationViewProps> = ({
           setLocation(value);
           setLocation_(value);
 
-          const backend_data = convertToMissionData(missionData);
-          backend_data.location = value;
+          missionData.location = value;
+          missionData.notes = notes;
 
-          await updateMission(backend_data);
+          await updateMission(convertToMissionData(missionData));
         }}
       />
 
@@ -125,10 +125,10 @@ export const ShowInformationView: React.FC<ShowInformationViewProps> = ({
         onValueChange={async (value) => {
           setNotes(value);
 
-          const backend_data = convertToMissionData(missionData);
-          backend_data.notes = value;
+          missionData.location = location;
+          missionData.notes = value;
 
-          await updateMission(backend_data);
+          await updateMission(convertToMissionData(missionData));
         }}
       />
     </div>


### PR DESCRIPTION
Hi,
this PR resolves issue #193. When changing location, the database is updated, but the internal state on the web browser isn't, meaning, continuing to change notes leads to a nonexistent mission (unknown location tag, i. e. location before the change), and vice versa. 