### PR TITLE
Implemented Rest API for topics

### DIFF
--- a/backend/restapi/models.py
+++ b/backend/restapi/models.py
@@ -79,16 +79,6 @@ class Topic(models.Model):
         unique_together = ["file", "type", "name"]
 
 
-class File_topics(models.Model):
-    """The relationship table to connect File and Topic"""
-
-    file = models.ForeignKey(File, on_delete=models.CASCADE)
-    topic = models.ForeignKey(Topic, on_delete=models.CASCADE)
-
-    class Meta:
-        unique_together = ["file", "topic"]
-
-
 """
 update db:
 python manage.py makemigrations

--- a/backend/restapi/models.py
+++ b/backend/restapi/models.py
@@ -79,6 +79,16 @@ class Topic(models.Model):
         unique_together = ["file", "type", "name"]
 
 
+class File_topics(models.Model):
+    """The relationship table to connect File and Topic"""
+
+    file = models.ForeignKey(File, on_delete=models.CASCADE)
+    topic = models.ForeignKey(Topic, on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ["file", "topic"]
+
+
 """
 update db:
 python manage.py makemigrations

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
-from .models import File_topics, Mission, Topic
+from .models import Mission, Topic
 from .models import File
 from .models import Mission_files
 from .models import Tag

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
-from .models import Mission
+from .models import File_topics, Mission, Topic
 from .models import File
 from .models import Mission_files
 from .models import Tag
@@ -75,3 +75,18 @@ class MissionTagSerializer(serializers.ModelSerializer):
         tag, self.tag_created = Tag.objects.get_or_create(name=tag_name)
         mission_tag, _ = Mission_tags.objects.get_or_create(mission=mission, tag=tag)
         return mission_tag
+
+
+class TopicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Topic
+        fields = ["id", "name", "type", "message_count", "frequency"]
+        
+
+class FileWithTopicsSerializer(serializers.ModelSerializer):
+    file = FileSerializer(read_only=True)
+    topics = TopicSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = File_topics
+        fields = ["file", "topics"]

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
-from .models import Mission, Topic
+from .models import Allowed_topic_names, Mission, Topic
 from .models import File
 from .models import Mission_files
 from .models import Tag
@@ -81,3 +81,9 @@ class TopicSerializer(serializers.ModelSerializer):
     class Meta:
         model = Topic
         fields = ["id", "name", "type", "message_count", "frequency"]
+
+
+class AllowedTopicNameSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Allowed_topic_names
+        fields = ["name"]

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -81,12 +81,3 @@ class TopicSerializer(serializers.ModelSerializer):
     class Meta:
         model = Topic
         fields = ["id", "name", "type", "message_count", "frequency"]
-        
-
-class FileWithTopicsSerializer(serializers.ModelSerializer):
-    file = FileSerializer(read_only=True)
-    topics = TopicSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = File_topics
-        fields = ["file", "topics"]

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -7,7 +7,15 @@ from django.utils import timezone
 from django.contrib.auth.models import User
 from django.core.files.storage.memory import InMemoryStorage
 from django.core.files.base import ContentFile
-from .models import Tag, Mission, Mission_tags, File, Mission_files
+from .models import (
+    Allowed_topic_names,
+    Tag,
+    Mission,
+    Mission_tags,
+    File,
+    Mission_files,
+    Topic,
+)
 import logging
 import urllib.parse
 
@@ -603,3 +611,136 @@ class SpecialTagNameTest(APIAuthTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Tag.objects.filter(name="create/").exists())
+
+
+class RestAPIAllowedTopicNamesTestCases(APIAuthTestCase):
+    def setUp(self):
+        super().setUp()
+        Allowed_topic_names.objects.create(name="Car1")
+        Allowed_topic_names.objects.create(name="Car2")
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_get_allowed_topic_names(self):
+        response = self.client.get(
+            reverse("allowed_topic_names"),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["name"], "Car1")
+        self.assertEqual(response.data[1]["name"], "Car2")
+
+    def test_create_allowed_topic_name(self):
+        response = self.client.post(
+            reverse("allowed_topic_names_create"),
+            {"name": "Car3"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "Car3")
+        self.assertTrue(Allowed_topic_names.objects.filter(name="Car3").exists())
+
+    def test_delete_allowed_topic_name(self):
+        response = self.client.delete(
+            reverse("allowed_topic_names_delete", kwargs={"name": "Car1"}),
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Allowed_topic_names.objects.filter(name="Car1").exists())
+
+
+class RestAPITopicsByFile(APIAuthTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # fake storage
+        self._field = File.file.field
+        self._default_storage = self._field.storage
+        test_storage = InMemoryStorage()
+        self._field.storage = test_storage
+
+        # create files
+        file_content = ContentFile("")
+        test_storage.save("path/to/file1", file_content)
+
+        super().setUp()
+        # Create a mission
+        self.mission = Mission.objects.create(
+            name="TestMission",
+            date=timezone.now(),
+            location="TestLocation",
+            notes="TestOther",
+        )
+
+        # Create file
+        self.file1 = File.objects.create(
+            id=0,
+            file="path/to/file1",
+            robot="TestRobot1",
+            duration=12000,
+            size=1024,
+        )
+
+        # Create allowed topic names
+        car1 = Allowed_topic_names(name="Car1")
+        car1.full_clean()
+        car1.save()
+
+        car2 = Allowed_topic_names(name="Car2")
+        car2.full_clean()
+        car2.save()
+
+        car3 = Allowed_topic_names(name="Car3")
+        car3.full_clean()
+        car3.save()
+
+        # Create topics
+        Topic.objects.create(
+            name=car1,
+            file=self.file1,
+            type="sensor",
+            message_count=124,
+            frequency=6.5,
+        )
+
+        Topic.objects.create(
+            name=car2,
+            file=self.file1,
+            type="camera",
+            message_count=1024,
+            frequency=60,
+        )
+
+        Topic.objects.create(
+            name=car3,
+            file=self.file1,
+            type="imu",
+            message_count=10000,
+            frequency=200,
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        self._field.storage = self._default_storage
+
+    def test_get_topics_by_file(self):
+        response = self.client.get(
+            reverse("get_topics_from_files", kwargs={"file_path": "path/to/file1"}),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+        self.assertEqual(response.data[0]["name"], "Car1")
+        self.assertEqual(response.data[0]["type"], "sensor")
+        self.assertEqual(response.data[0]["message_count"], 124)
+        self.assertEqual(response.data[0]["frequency"], 6.5)
+
+        self.assertEqual(response.data[1]["name"], "Car2")
+        self.assertEqual(response.data[1]["type"], "camera")
+        self.assertEqual(response.data[1]["message_count"], 1024)
+        self.assertEqual(response.data[1]["frequency"], 60)
+
+        self.assertEqual(response.data[2]["name"], "Car3")
+        self.assertEqual(response.data[2]["type"], "imu")
+        self.assertEqual(response.data[2]["message_count"], 10000)
+        self.assertEqual(response.data[2]["frequency"], 200)

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -664,7 +664,6 @@ class RestAPITopicsByFile(APIAuthTestCase):
         file_content = ContentFile("")
         test_storage.save("path/to/file1", file_content)
 
-        super().setUp()
         # Create a mission
         self.mission = Mission.objects.create(
             name="TestMission",

--- a/backend/restapi/urls.py
+++ b/backend/restapi/urls.py
@@ -1,5 +1,8 @@
 from django.urls import include, path
 from .views import (
+    allowed_topic_names,
+    allowed_topic_names_create,
+    allowed_topic_names_delete,
     get_missions,
     create_mission,
     get_topics_from_files,
@@ -47,5 +50,20 @@ urlpatterns = [
         "topics/<path:file_path>",
         get_topics_from_files,
         name="get_topics_from_files",
+    ),
+    path(
+        "topics-names",
+        allowed_topic_names,
+        name="allowed_topic_names",
+    ),
+    path(
+        "topics-names/create/",
+        allowed_topic_names_create,
+        name="allowed_topic_names_create",
+    ),
+    path(
+        "topics-names/<str:name>",
+        allowed_topic_names_delete,
+        name="allowed_topic_names_delete",
     ),
 ]

--- a/backend/restapi/urls.py
+++ b/backend/restapi/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 from .views import (
     get_missions,
     create_mission,
+    get_topics_from_files,
     mission_detail,
     get_tags,
     create_tag,
@@ -42,4 +43,9 @@ urlpatterns = [
         name="get_files_by_mission_id",
     ),
     path("auth/", include("dj_rest_auth.urls")),
+    path(
+        "missions/<str:file_path>/files/topics",
+        get_topics_from_files,
+        name="get_topics_from_files",
+    ),
 ]

--- a/backend/restapi/urls.py
+++ b/backend/restapi/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     ),
     path("auth/", include("dj_rest_auth.urls")),
     path(
-        "missions/<str:file_path>/files/topics",
+        "topics/<path:file_path>",
         get_topics_from_files,
         name="get_topics_from_files",
     ),

--- a/backend/restapi/views.py
+++ b/backend/restapi/views.py
@@ -3,13 +3,13 @@ from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from rest_framework import status
-from .models import File, File_topics, Tag, Mission, Mission_tags, Mission_files
+from .models import File, Tag, Mission, Mission_tags, Mission_files, Topic
 from .serializer import (
-    FileWithTopicsSerializer,
     TagSerializer,
     MissionSerializer,
     MissionTagSerializer,
     FileWithTypeSerializer,
+    TopicSerializer,
 )
 import urllib.parse
 
@@ -83,8 +83,8 @@ def get_topics_from_files(request, file_path):
     except File.DoesNotExist:
         raise NotFound(f"File with path {file_path} not found")
 
-    file_topics = File_topics.objects.filter(file=file)
-    serializer = FileWithTopicsSerializer(file_topics, many=True)
+    topics = Topic.objects.filter(file=file)
+    serializer = TopicSerializer(topics, many=True)
     return Response(serializer.data, status=status.HTTP_200_OK)
 
 

--- a/backend/restapi/views.py
+++ b/backend/restapi/views.py
@@ -3,8 +3,9 @@ from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from rest_framework import status
-from .models import Tag, Mission, Mission_tags, Mission_files
+from .models import File, File_topics, Tag, Mission, Mission_tags, Mission_files
 from .serializer import (
+    FileWithTopicsSerializer,
     TagSerializer,
     MissionSerializer,
     MissionTagSerializer,
@@ -66,6 +67,24 @@ def get_files_by_mission_id(request, mission_id):
         raise NotFound(f"Mission with ID {mission_id} not found")
     mission_files = Mission_files.objects.filter(mission__id=mission.id)
     serializer = FileWithTypeSerializer(mission_files, many=True)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+def get_topics_from_files(request, file_path):
+    """
+    List all files with type of a mission by ID
+    ### Returns
+    Response with list of files with type in json format\
+    Or NotFound exception
+    """
+    try:
+        file = File.objects.get(file=file_path)
+    except File.DoesNotExist:
+        raise NotFound(f"File with path {file_path} not found")
+
+    file_topics = File_topics.objects.filter(file=file)
+    serializer = FileWithTopicsSerializer(file_topics, many=True)
     return Response(serializer.data, status=status.HTTP_200_OK)
 
 

--- a/backend/restapi/views.py
+++ b/backend/restapi/views.py
@@ -3,8 +3,17 @@ from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from rest_framework import status
-from .models import File, Tag, Mission, Mission_tags, Mission_files, Topic
+from .models import (
+    Allowed_topic_names,
+    File,
+    Tag,
+    Mission,
+    Mission_tags,
+    Mission_files,
+    Topic,
+)
 from .serializer import (
+    AllowedTopicNameSerializer,
     TagSerializer,
     MissionSerializer,
     MissionTagSerializer,
@@ -73,19 +82,64 @@ def get_files_by_mission_id(request, mission_id):
 @api_view(["GET"])
 def get_topics_from_files(request, file_path):
     """
-    List all files with type of a mission by ID
+    List all topics of a file
     ### Returns
-    Response with list of files with type in json format\
-    Or NotFound exception
+    Response with list of topics in json format
     """
     try:
         file = File.objects.get(file=file_path)
     except File.DoesNotExist:
-        raise NotFound(f"File with path {file_path} not found")
-
+        return Response(status=status.HTTP_404_NOT_FOUND)
     topics = Topic.objects.filter(file=file)
     serializer = TopicSerializer(topics, many=True)
     return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+def allowed_topic_names(request):
+    """
+    List all allowed topic names
+    ### Returns
+    List of allowed topic names in json format
+    """
+    topic_names = Allowed_topic_names.objects.all()
+    serializer = AllowedTopicNameSerializer(topic_names, many=True)
+    return Response(serializer.data)
+
+
+@api_view(["POST"])
+def allowed_topic_names_create(request):
+    """
+    Creates a new allowed topic name
+    ### Parameters
+    request: POST Request containing name of the allowed topic name
+    ### Returns
+    Response with data of created allowed topic name object containing name\
+    Or HTTP_400_BAD_REQUEST Response
+    """
+    serializer = AllowedTopicNameSerializer(data=request.data)
+    if serializer.is_valid():
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(["DELETE"])
+def allowed_topic_names_delete(request, name):
+    """
+    Delete an allowed topic name
+    ### Parameters
+    name: name of the allowed topic name
+    ### Returns
+    success response or
+    HTTP_404_NOT_FOUND if allowed topic name not found
+    """
+    try:
+        allowed_topic_name = Allowed_topic_names.objects.get(name=name)
+    except Mission.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+    allowed_topic_name.delete()
+    return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(["GET"])

--- a/backend/restapi/views.py
+++ b/backend/restapi/views.py
@@ -136,7 +136,7 @@ def allowed_topic_names_delete(request, name):
     """
     try:
         allowed_topic_name = Allowed_topic_names.objects.get(name=name)
-    except Mission.DoesNotExist:
+    except Allowed_topic_names.DoesNotExist:
         return Response(status=status.HTTP_404_NOT_FOUND)
     allowed_topic_name.delete()
     return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/restapi/views.py
+++ b/backend/restapi/views.py
@@ -134,6 +134,7 @@ def allowed_topic_names_delete(request, name):
     success response or
     HTTP_404_NOT_FOUND if allowed topic name not found
     """
+    name = urllib.parse.unquote(name)
     try:
         allowed_topic_name = Allowed_topic_names.objects.get(name=name)
     except Allowed_topic_names.DoesNotExist:

--- a/docs/restapi/README.md
+++ b/docs/restapi/README.md
@@ -121,4 +121,24 @@ For more details about how to use the endpoints refer to the [dj-rest-auth docum
   - The URL is of the format `restapi/missions/<int:mission_id>/files/`
   - The result will be a list of files associated with the specific mission.
 
+- GET request to list all topics for a file path
+  - Using a [GET Request](http://localhost:8000/restapi/topics/yourpathhere) the topics from a file path can be listed.
+  - The URL is of the format `restapi/topics/<path:file_path>`
+  - The result will be a list of topics.
+
+- GET request to list all allowed topic names
+  - Using a [GET Request](http://localhost:8000/restapi/topics-names/) the allowed topic names can be listed.
+  - The URL is of the format `restapi/topics-names/`
+  - The result will be a list of allowed topic names.
+
+- POST request to add an allowed topic name
+  - Using a [POST Request](http://localhost:8000/restapi/topics-names/create/) with a name field.
+  - The URL is of the format `restapi/topics-names/create/`
+  - The result will be an object containing the added name.
+
+- DELETE request to delete an allowed topic name
+  - Using a [DELETE Request](http://localhost:8000/topics-names/test) with the name.
+  - The URL is of the format `topics-names/<str:name>`
+  - The result will be HTTP_204_NO_CONTENT or HTTP_404_NOT_FOUND if the name is not found.
+  
 If you want to confirm your actions further, you can always check the current state of the database. The steps to achieve this are described in docs/database.


### PR DESCRIPTION
Hi, this resolves PR #166.

It adds a way to fetch Topics by a file path, which is unique to the system. Topics are only allowed to have specific names, for this purpose, GET, POST and DELETE requests for managing the allowed topic names are added as well.

All new additions are fully tested and documented.