### PR TITLE
Added frontend error handling

### DIFF
--- a/frontend/app/pages/error/ErrorPage.module.css
+++ b/frontend/app/pages/error/ErrorPage.module.css
@@ -1,0 +1,27 @@
+.root {
+    padding-top: 80px;
+    padding-bottom: 80px;
+  }
+  
+.code {
+    text-align: center;
+    font-weight: 900;
+    font-size: 100px;
+    line-height: 1;
+    margin-bottom: calc(1.5 * var(--mantine-spacing-xl));
+    color: var(--mantine-color-gray-2);
+}
+
+.message {
+    font-family: 'Greycliff CF', var(--mantine-font-family);
+    text-align: center;
+    font-weight: 900;
+    font-size: 40px;
+}
+
+.description {
+    max-width: 500px;
+    margin: auto;
+    margin-top: var(--mantine-spacing-xl);
+    margin-bottom: calc(1.5 * var(--mantine-spacing-xl));
+}

--- a/frontend/app/pages/error/ErrorPage.tsx
+++ b/frontend/app/pages/error/ErrorPage.tsx
@@ -24,7 +24,7 @@ export function ServerError({ statusCode, errorMessage }: ServerErrorProps) {
           component="a"
           href="/"
         >
-          Take me to the main page
+          Return to the main page
         </Button>
       </Group>
     </Container>

--- a/frontend/app/pages/error/ErrorPage.tsx
+++ b/frontend/app/pages/error/ErrorPage.tsx
@@ -1,0 +1,33 @@
+import classes from "./ErrorPage.module.css";
+import { Button, Container, Group, Text, Title } from "@mantine/core";
+import { MetaFunction, useNavigate } from "@remix-run/react";
+
+interface ServerErrorProps {
+  statusCode: string;
+  errorMessage: string;
+}
+
+export function ServerError({ statusCode, errorMessage }: ServerErrorProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Container className={classes.root}>
+      <div className={classes.code}>{statusCode}</div>
+      <Title className={classes.message}>{errorMessage}</Title>
+      <Text c="dimmed" size="lg" ta="center" className={classes.description}>
+        You might have entered the address
+        incorrectly, or the page may have been moved to a different location.
+      </Text>
+      <Group justify="center">
+        <Button
+          variant="gradient"
+          gradient={{ from: "yellow", to: "orange", deg: 269 }}
+          size="md"
+          onClick={() => navigate("/")}
+        >
+          Take me back to main page
+        </Button>
+      </Group>
+    </Container>
+  );
+}

--- a/frontend/app/pages/error/ErrorPage.tsx
+++ b/frontend/app/pages/error/ErrorPage.tsx
@@ -1,6 +1,6 @@
 import classes from "./ErrorPage.module.css";
 import { Button, Container, Group, Text, Title } from "@mantine/core";
-import { MetaFunction, useNavigate } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 
 interface ServerErrorProps {
   statusCode: string;
@@ -8,8 +8,6 @@ interface ServerErrorProps {
 }
 
 export function ServerError({ statusCode, errorMessage }: ServerErrorProps) {
-  const navigate = useNavigate();
-
   return (
     <Container className={classes.root}>
       <div className={classes.code}>{statusCode}</div>
@@ -23,9 +21,10 @@ export function ServerError({ statusCode, errorMessage }: ServerErrorProps) {
           variant="gradient"
           gradient={{ from: "yellow", to: "orange", deg: 269 }}
           size="md"
-          onClick={() => navigate("/")}
+          component="a"
+          href="/"
         >
-          Take me back to main page
+          Take me to the main page
         </Button>
       </Group>
     </Container>

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -2,12 +2,48 @@ import "@mantine/core/styles.css";
 
 import { MantineProvider, ColorSchemeScript } from "@mantine/core";
 import {
+  isRouteErrorResponse,
   Links,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
+  useRouteError,
 } from "@remix-run/react";
+import { ServerError } from "./pages/error/ErrorPage";
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  const statusCode = isRouteErrorResponse(error)
+    ? `${error.status}`
+    : "Unknown";
+  const errorMessage = isRouteErrorResponse(error)
+    ? error.statusText
+    : error instanceof Error
+    ? error.message
+    : "Unknown Error";
+
+  return (
+    <html lang="en">
+      <head>
+        <title>Something went wrong :/</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <Links />
+        <ColorSchemeScript />
+        <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+      </head>
+      <body>
+        <MantineProvider>
+          <ServerError statusCode={statusCode} errorMessage={errorMessage} />
+        </MantineProvider>
+        <Scripts />
+      </body>
+    </html>
+  );
+}
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -24,25 +24,7 @@ export function ErrorBoundary() {
     ? error.message
     : "Unknown Error";
 
-  return (
-    <html lang="en">
-      <head>
-        <title>Something went wrong :/</title>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <Meta />
-        <Links />
-        <ColorSchemeScript />
-        <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-      </head>
-      <body>
-        <MantineProvider>
-          <ServerError statusCode={statusCode} errorMessage={errorMessage} />
-        </MantineProvider>
-        <Scripts />
-      </body>
-    </html>
-  );
+  return <ServerError statusCode={statusCode} errorMessage={errorMessage} />;
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/frontend/app/routes/dataset.tsx
+++ b/frontend/app/routes/dataset.tsx
@@ -3,6 +3,7 @@ import {
   data,
   MetaFunction,
   redirect,
+  useLoaderData,
   useSearchParams,
 } from "@remix-run/react";
 import { CreateAppShell } from "~/layout/AppShell";
@@ -19,20 +20,26 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   if (!user) throw redirect("/login");
 
-  return data(null);
-}
-
-function Dataset() {
-  const [searchParams] = useSearchParams();
-  const fileName = searchParams.get("fileName");
-  const duration = searchParams.get("duration");
-  const size = searchParams.get("size");
+  let url = new URL(request.url);
+  const fileName = url.searchParams.get("fileName");
+  const duration = url.searchParams.get("duration");
+  const size = url.searchParams.get("size");
 
   if (!fileName || !duration || !size)
     throw new Response(null, {
-      status: 404,
-      statusText: "Invalid file name, duration or size.",
+      status: 400,
+      statusText: "Invalid URL",
     });
+
+  return {
+    fileName,
+    duration,
+    size,
+  };
+}
+
+function Dataset() {
+  const { fileName, duration, size } = useLoaderData<typeof loader>();
 
   return (
     <DatasetView file={fileName} duration={duration} size={size}></DatasetView>

--- a/frontend/app/routes/dataset.tsx
+++ b/frontend/app/routes/dataset.tsx
@@ -28,7 +28,11 @@ function Dataset() {
   const duration = searchParams.get("duration");
   const size = searchParams.get("size");
 
-  if (!fileName || !duration || !size) return <h1>Invalid URL</h1>;
+  if (!fileName || !duration || !size)
+    throw new Response(null, {
+      status: 404,
+      statusText: "Invalid file name, duration or size.",
+    });
 
   return (
     <DatasetView file={fileName} duration={duration} size={size}></DatasetView>

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -8,7 +8,11 @@ import {
 } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { DetailViewData, MissionData, RenderedMission, Tag } from "~/data";
-import { getFormattedDetails, getTotalDuration, getTotalSize } from "~/fetchapi/details";
+import {
+  getFormattedDetails,
+  getTotalDuration,
+  getTotalSize,
+} from "~/fetchapi/details";
 import { getMission } from "~/fetchapi/missions";
 import { getTagsByMission } from "~/fetchapi/tags";
 import { CreateAppShell } from "~/layout/AppShell";
@@ -46,13 +50,15 @@ function Detail() {
   // Detail View data
   const [detailViewData, setDetailViewData] = useState<DetailViewData>();
   const [totalSize, setTotalSize] = useState<string>("0 GB");
-  const [totalDuration, setTotalDuration] = useState<string>(
-    "00:00:00"
-  );
+  const [totalDuration, setTotalDuration] = useState<string>("00:00:00");
 
   const numberId = Number(id);
 
-  if (isNaN(numberId)) return <h1>Invalid URL</h1>;
+  if (isNaN(numberId))
+    throw new Response(null, {
+      status: 404,
+      statusText: "Invalid ID.",
+    });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -75,16 +81,15 @@ function Detail() {
 
         setMissionData(transformedMission);
         setAllTags(tags);
-        
+
         // data for the detail view
         setDetailViewData(await getFormattedDetails(mission.id));
-        
+
         // data for the information view (size)
         setTotalSize(await getTotalSize(mission.id));
 
         // data for the information view (duration)
         setTotalDuration(await getTotalDuration(mission.id));
-
       } catch (e: any) {
         if (e instanceof Error) {
           setError(e.message);


### PR DESCRIPTION
This PR resolves issue #90 by introducing an error screen handled with the [Remix Error Boundary](https://remix.run/docs/en/main/route/error-boundary#errorboundary). 

The new page appears on all page not found errors:
![image](https://github.com/user-attachments/assets/b31e62d3-6d4d-4ef9-92a8-2119df0bb23f)
And on invalid urls on the dataset and detail page.
![image](https://github.com/user-attachments/assets/ae8c1904-580d-4da2-abb0-f2300d598d9b)
