### PR TITLE
Added name truncation

### DIFF
--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -4,7 +4,7 @@ import { getHeaders } from "./headers";
 import {
   transformDurations,
   transformSizes,
-} from "~/utilities/FormatTransformer";
+} from "~/utilities/FormatHandler";
 
 // Get details by mission
 export const getDetailsByMission = async (

--- a/frontend/app/pages/details/DetailsView.tsx
+++ b/frontend/app/pages/details/DetailsView.tsx
@@ -5,7 +5,7 @@ import { ShowDatasets } from "./DatasetTable";
 import { DetailViewData, RenderedMission, Tag } from "~/data";
 import AbstractPage from "../AbstractPage";
 import { ShowInformationView } from "./InformationView";
-import { formatRobotNames } from "~/utilities/FormatTransformer";
+import { formatRobotNames } from "~/utilities/FormatHandler";
 
 interface DetailsViewProps {
   missionData: RenderedMission;

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -28,7 +28,7 @@ import { useNavigate } from "@remix-run/react";
 import { getMissions } from "~/fetchapi/missions";
 import { addTagToMission, changeTagColor, changeTagName, createTag, deleteTag, getMissionsByTag, getTags, getTagsByMission, removeTagFromMission } from "~/fetchapi/tags";
 import { getRobotNames, getTotalDuration, getTotalSize } from "~/fetchapi/details";
-import { formatRobotNames } from "~/utilities/FormatTransformer";
+import { formatRobotNames } from "~/utilities/FormatHandler";
 
 interface ThProps {
   children: React.ReactNode;

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -16,6 +16,7 @@ import { getMission } from "~/fetchapi/missions";
 import { getTagsByMission, getTags } from "~/fetchapi/tags";
 import { CreateAppShell } from "~/layout/AppShell";
 import DetailsView from "~/pages/details/DetailsView";
+import { transformFilePaths } from "~/utilities/FormatHandler";
 import { sessionStorage } from "~/utilities/LoginHandler";
 
 export const meta: MetaFunction = () => {
@@ -61,6 +62,7 @@ function Detail() {
   const [detailViewData, setDetailViewData] = useState<DetailViewData>();
   const [totalSize, setTotalSize] = useState<string>("0 GB");
   const [totalDuration, setTotalDuration] = useState<string>("00:00:00");
+  const [basePath, setBasePath] = useState<string>("");
 
   useEffect(() => {
     const fetchData = async () => {
@@ -87,6 +89,16 @@ function Detail() {
         
         // data for the detail view
         setDetailViewData(await getFormattedDetails(mission.id));
+
+        // transform files manually, to obtain the correct base path
+        if (detailViewData) {
+          const { commonPath, files } = transformFilePaths(detailViewData.files);
+
+          setBasePath(commonPath);
+
+          detailViewData.files = files;
+          setDetailViewData(detailViewData);
+        }
 
         // data for the information view (size)
         setTotalSize(await getTotalSize(mission.id));

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -88,17 +88,16 @@ function Detail() {
         setAllTags(allTags);
         
         // data for the detail view
-        setDetailViewData(await getFormattedDetails(mission.id));
+        let detailViewData = await getFormattedDetails(mission.id);
 
         // transform files manually, to obtain the correct base path
-        if (detailViewData) {
-          const { commonPath, files } = transformFilePaths(detailViewData.files);
+        const { commonPath, files } = transformFilePaths(detailViewData.files);
 
-          setBasePath(commonPath);
+        setBasePath(commonPath);
 
-          detailViewData.files = files;
-          setDetailViewData(detailViewData);
-        }
+        detailViewData.files = files;
+        
+        setDetailViewData(detailViewData);
 
         // data for the information view (size)
         setTotalSize(await getTotalSize(mission.id));

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -92,11 +92,9 @@ function Detail() {
 
         // transform files manually, to obtain the correct base path
         const { commonPath, files } = transformFilePaths(detailViewData.files);
-
-        setBasePath(commonPath);
-
         detailViewData.files = files;
         
+        setBasePath(commonPath);
         setDetailViewData(detailViewData);
 
         // data for the information view (size)

--- a/frontend/app/utilities/FormatHandler.tsx
+++ b/frontend/app/utilities/FormatHandler.tsx
@@ -75,3 +75,55 @@ export function formatRobotNames(
     return uniqueRobots.join(", ");
   }
 }
+
+// Transforms file paths and removes the common path prefix. It returns the transformed file name list, but also the global
+// path prefix.
+// ["/home/simon/Desktop/Teamproject/polybot_mission_db/backend/media/2025.11.11_hiho/train_recording1.mcap",
+// "/home/simon/Desktop/Teamproject/polybot_mission_db/backend/media/2025.11.11_hiho/train_recording2.mcap"]
+// => common path: "/home/simon/Desktop/Teamproject/polybot_mission_db/backend/media/2025.11.11_hiho/"
+// => files: ["train_recording1.mcap", "train_recording2.mcap"]
+
+export function transformFilePaths(filePaths: string[]): {
+  commonPath: string;
+  files: string[];
+} {
+  if (filePaths.length === 0) {
+    return { commonPath: "", files: [] };
+  }
+
+  if (filePaths.length === 1) {
+    const pathSegments = filePaths[0].split("/");
+    const fileName = pathSegments.pop() ?? "";
+    const commonPath =
+      pathSegments.join("/") + (pathSegments.length > 0 ? "/" : "");
+
+    return { commonPath, files: [fileName] };
+  }
+
+  const splitPaths = filePaths.map((path) => path.split("/"));
+  const minSegmentsLength = Math.min(
+    ...splitPaths.map((segments) => segments.length)
+  );
+
+  let commonSegmentCount = 0;
+  for (let segmentIndex = 0; segmentIndex < minSegmentsLength; segmentIndex++) {
+    const segment = splitPaths[0][segmentIndex];
+    if (
+      splitPaths.every((pathSegments) => pathSegments[segmentIndex] === segment)
+    ) {
+      commonSegmentCount++;
+    } else break;
+  }
+
+  let commonPath = splitPaths[0].slice(0, commonSegmentCount).join("/");
+  if (!commonPath.startsWith("/") && filePaths[0].startsWith("/"))
+    commonPath = "/" + commonPath;
+
+  if (commonPath && !commonPath.endsWith("/")) commonPath += "/";
+
+  const files = filePaths.map((fullPath) => {
+    return fullPath.replace(commonPath, "");
+  });
+
+  return { commonPath, files };
+}


### PR DESCRIPTION
Hi,
this PR resolves the first task of issue #209 by adding a method to truncate names in the detail view.

The main idea behind this is to truncate the common file path, the common file name at the end is not truncated.

For example:
```
/home/simon/Desktop/Teamproject/polybot_mission_db/backend/media/2025.11.11_hiho/train_recording1.mcap
/home/simon/Desktop/Teamproject/polybot_mission_db/backend/media/2025.11.11_hiho/train_recording2.mcap
```

The common path is `/home/simon/Desktop/Teamproject/polybot_mission_db/backend/media/2025.11.11_hiho/` and the files are renamed to `train_recording1.mcap` and `train_recording2.mcap`

![image](https://github.com/user-attachments/assets/31358734-f60c-4163-8fa0-c371aee0b700)

This removes visual redundancy while keeping relevant information intact. 

I decided not to modify `getFormattedDetails` because `commonPath` is required for the following PR enabling copying the entire file path. For this purpose, the common file path is stored in a new state variable:
`setBasePath(commonPath);`
