### PR TITLE
Cli sync files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.7.1
     hooks:
-      # Run the linter.
-      - id: ruff
-      # Run the formatter.
+      # Run the formatter first
       - id: ruff-format
+
+      # Then run the linter (with autofix enabled)
+      - id: ruff
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:
       - id: prettier
-        files: \.tsx$
+        files: \.(tsx|ts|js|jsx|json)$

--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from .Command import Command
 from django.core.files.storage import DefaultStorage
 from restapi.models import Mission
-from .SyncCommand import sync_mcap_files
 
 
 class AddFolderCommand(Command):
@@ -35,6 +34,7 @@ def add_mission_from_folder(folder_path, location=None, notes=None):
     Adds a mission to the database based on the given folder path.
     Calls sync_mcap_files to process and store associated .mcap and metadata files.
     """
+    from .SyncCommand import sync_mcap_files
     folder_name = os.path.basename(folder_path)
     try:
         date_str, name = folder_name.split("_", 1)

--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -1,10 +1,10 @@
 import os
 import logging
-import yaml
 from datetime import datetime
 from .Command import Command
 from django.core.files.storage import DefaultStorage
-from restapi.models import Mission, File, Mission_files
+from restapi.models import Mission
+from .SyncCommand import sync_mcap_files
 
 
 class AddFolderCommand(Command):
@@ -30,136 +30,27 @@ class AddFolderCommand(Command):
 storage = DefaultStorage()
 
 
-def get_duration(path):
-    metadata = load_yaml_metadata(path)
-    duration = get_mcap_duration_from_yaml(metadata)
-    return duration
-
-
-def load_yaml_metadata(yaml_filepath):
-    """Load YAML metadata."""
-    with storage.open(yaml_filepath, "r") as file:
-        return yaml.safe_load(file)
-
-
-def get_mcap_duration_from_yaml(metadata):
-    """Extract duration in seconds from YAML."""
-    nanoseconds = (
-        metadata.get("rosbag2_bagfile_information", {})
-        .get("duration", {})
-        .get("nanoseconds", 0)
-    )
-    return nanoseconds / 1e9
-
-
-def check_mission(name, date):
+def add_mission_from_folder(folder_path, location=None, notes=None):
     """
-    Checks if Mission with the same name and date exists
+    Adds a mission to the database based on the given folder path.
+    Calls sync_mcap_files to process and store associated .mcap and metadata files.
     """
-    return Mission.objects.filter(name=name, date=date).exists()
-
-
-def extract_info_from_folder(folder_name):
-    """
-    Extract date and name from folder name
-    ### Parameters
-    folder_name: basename of folder in format YYYY.MM.DD_missionname
-    ### Returns
-    date: date object of extracted date
-    name: extracted mission name
-    """
+    folder_name = os.path.basename(folder_path)
     try:
         date_str, name = folder_name.split("_", 1)
         mission_date = datetime.strptime(date_str, "%Y.%m.%d").date()
-        return mission_date, name
     except ValueError:
-        logging.error(
-            f"Folder name '{folder_name}' does not match the expected format (YYYY.MM.DD_missionname)."
-        )
-        return None, None
+        logging.error(f"Invalid folder name format: {folder_name}")
+        return
 
+    if Mission.objects.filter(name=name, date=mission_date).exists():
+        logging.warning(f"Mission '{name}' already exists, skipping.")
+        return
 
-def get_details_id(path):
     try:
-        file = File.objects.get(file=path)
-        return file
-    except File.DoesNotExist:
-        print(f"No Details found for file '{path}'")
-        return None
-
-
-def add_mission_from_folder(folder_path, location=None, notes=None):
-    """
-    Add mission to DB with data from filesystem
-    ### Parameters
-    folder_path: path to a folder without trailing /\\
-    location: optional string containing information about the location\\
-    other: optional string containing other extra information
-    """
-    folder_name = os.path.basename(folder_path)
-    mission_date, name = extract_info_from_folder(folder_name)
-
-    if mission_date and name:
-        if not check_mission(name, mission_date):
-            mission = Mission(
-                name=name, date=mission_date, location=location, notes=notes
-            )
-            try:
-                mission.save()
-                logging.info(f"Mission '{name}' from folder '{folder_name}' added.")
-                robot = None
-                add_details(folder_path, robot, mission)
-            except Exception as e:
-                logging.error(f"Error adding mission: {e}")
-        else:
-            logging.warning("skipping because this mission has already been added")
-    else:
-        logging.warning("Skipping folder due to naming issues.")
-
-
-def add_details(mission_path, robot, id):
-    """
-    iterates through the folders and subfolders to find the mcap files and metadata files
-    this information is then stored in the database
-    """
-    mcap_path, metadata = None, None
-
-    # storage.listdir returns a tuple where the first element is a list of all directories
-    # and the second element a list of all files
-    for folder in storage.listdir(mission_path)[0]:
-        folder_path = os.path.join(mission_path, folder)
-        typ = os.path.basename(folder_path)
-
-        for subfolder in storage.listdir(folder_path)[0]:
-            subfolder_path = os.path.join(folder_path, subfolder)
-
-            for item in storage.listdir(subfolder_path)[1]:
-                if os.path.join(subfolder_path, item).endswith(".mcap"):
-                    mcap_path = os.path.join(subfolder_path, item)
-                if os.path.join(subfolder_path, item).endswith(".yaml"):
-                    metadata = os.path.join(subfolder_path, item)
-            if mcap_path and metadata:
-                size = storage.size(mcap_path)
-                duration = get_duration(metadata)
-                save_Details(mcap_path, size, duration, robot)
-                details_id = get_details_id(mcap_path)
-                save_missionfiles(id, details_id, typ)
-
-
-def save_missionfiles(mission_id, details_id, typ):
-    try:
-        files = Mission_files(mission=mission_id, file=details_id, type=typ)
-        files.save()
+        mission = Mission(name=name, date=mission_date, location=location, notes=notes)
+        mission.save()
+        logging.info(f"Mission '{name}' added successfully.")
+        sync_mcap_files(folder_path, mission)
     except Exception as e:
-        logging.error(f"Error Adding Mission_files: {e}")
-
-
-def save_Details(path, size, duration, robot):
-    if size and duration:
-        file = File(file=path, robot=robot, duration=duration, size=size)
-        try:
-            file.save()
-        except Exception as e:
-            logging.error(f"Error Adding Details: {e}")
-    else:
-        logging.warning("Skipping due to issues with the metadata")
+        logging.error(f"Error adding mission: {e}")

--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -52,6 +52,9 @@ def add_mission_from_folder(folder_path, location=None, notes=None):
         mission = Mission(name=name, date=mission_date, location=location, notes=notes)
         mission.save()
         logging.info(f"Mission '{name}' added successfully.")
-        sync_mcap_files(folder_path, mission)
     except Exception as e:
         logging.error(f"Error adding mission: {e}")
+    try:
+        sync_mcap_files(folder_path, mission)
+    except Exception as e:
+        logging.error(f"Error syncing files: {e}")

--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -35,6 +35,7 @@ def add_mission_from_folder(folder_path, location=None, notes=None):
     Calls sync_mcap_files to process and store associated .mcap and metadata files.
     """
     from .SyncCommand import sync_mcap_files
+
     folder_name = os.path.basename(folder_path)
     try:
         date_str, name = folder_name.split("_", 1)

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -9,6 +9,7 @@ from .DeleteFolderCommand import delete_mission_from_folder
 from restapi.models import File, Mission, Mission_files, Tag
 import json
 
+
 # Create a custom logging handler to track if any log message was emitted
 class LogTracker(logging.Handler):
     def __init__(self):
@@ -17,6 +18,7 @@ class LogTracker(logging.Handler):
 
     def emit(self, record):
         self.log_occurred = True
+
 
 class SyncCommand(Command):
     name = "sync"
@@ -30,6 +32,7 @@ class SyncCommand(Command):
 
 storage = DefaultStorage()
 
+
 def sync_mcap_files(mission_path, mission):
     """
     Syncs .mcap and metadata files:
@@ -37,7 +40,9 @@ def sync_mcap_files(mission_path, mission):
     - Removes files from the database if they are missing.
     """
 
-    existing_files = {mf.file.file for mf in Mission_files.objects.filter(mission=mission)}
+    existing_files = {
+        mf.file.file for mf in Mission_files.objects.filter(mission=mission)
+    }
     current_files = set()
 
     for folder in storage.listdir(mission_path)[0]:
@@ -62,12 +67,21 @@ def sync_mcap_files(mission_path, mission):
                     try:
                         size = storage.size(mcap_path)
                         metadata = load_yaml_metadata(metadata_path)
-                        duration = metadata.get("rosbag2_bagfile_information", {}).get("duration", {}).get("nanoseconds", 0) / 1e9
+                        duration = (
+                            metadata.get("rosbag2_bagfile_information", {})
+                            .get("duration", {})
+                            .get("nanoseconds", 0)
+                            / 1e9
+                        )
                         file = File(file=mcap_path, duration=duration, size=size)
                         file.save()
-                        mission_file = Mission_files(mission=mission, file=file, type=typ)
+                        mission_file = Mission_files(
+                            mission=mission, file=file, type=typ
+                        )
                         mission_file.save()
-                        logging.info(f"Added new file {mcap_path} for mission {mission.name}.")
+                        logging.info(
+                            f"Added new file {mcap_path} for mission {mission.name}."
+                        )
                     except Exception as e:
                         logging.error(f"Error processing {mcap_path}: {e}")
 
@@ -78,7 +92,10 @@ def sync_mcap_files(mission_path, mission):
             file.delete()
             logging.info(f"Deleted missing file {file_path} from database.")
         except File.DoesNotExist:
-            logging.warning(f"File {file_path} not found in database (already deleted).")
+            logging.warning(
+                f"File {file_path} not found in database (already deleted)."
+            )
+
 
 def load_yaml_metadata(yaml_filepath):
     """Loads YAML metadata."""

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -131,7 +131,6 @@ def sync_folder():
         if not mission.was_modified:
             continue
         # else save metadata
-        modified_mission_found = True
         Mission.objects.filter(id=mission.id).update(was_modified=False)
         tags = Tag.objects.filter(mission_tags__mission=mission)
         tag_serializer = TagSerializer(tags, many=True)

--- a/backend/cli_commands/test_add_folder.py
+++ b/backend/cli_commands/test_add_folder.py
@@ -1,126 +1,60 @@
-import os
-from django.test import TestCase
-from restapi.models import Mission, File, Mission_files
-from cli_commands.AddFolderCommand import (
-    add_mission_from_folder,
-    extract_info_from_folder,
-)
-import cli_commands.AddFolderCommand as AddFolderCommand
-from datetime import datetime
 import logging
+from datetime import datetime
+from django.test import TestCase
+import cli_commands.SyncCommand as SyncCommand
+from restapi.models import Mission, File, Mission_files
+from .AddFolderCommand import add_mission_from_folder
 from django.core.files.base import ContentFile
 from django.core.files.storage.memory import InMemoryStorage
 
 
 class ErrorCatchingTests(TestCase):
-    def test_add_mission_from_folder(self):
-        with self.assertLogs(level="WARNING") as log:
-            add_mission_from_folder("2024.13.02_test_add_mission")
-            self.assertFalse(
-                Mission.objects.filter(
-                    name="test_add_mission", date="2024-12-02"
-                ).exists()
-            )
-            self.assertEqual(
+    def test_add_mission_invalid_folder_name(self):
+        with self.assertLogs(level="ERROR") as log:
+            add_mission_from_folder("2024.13.02_invalid")
+            self.assertFalse(Mission.objects.exists())
+            self.assertIn(
+                "ERROR:root:Invalid folder name format: 2024.13.02_invalid",
                 log.output,
-                [
-                    "ERROR:root:Folder name '2024.13.02_test_add_mission' does not match the expected format (YYYY.MM.DD_missionname).",
-                    "WARNING:root:Skipping folder due to naming issues.",
-                ],
-            )
-
-    def test_extract_info_from_folder(self):
-        with self.assertLogs(level="WARNING") as log:
-            mission_date, name = extract_info_from_folder("2024.13.30_test")
-            self.assertIsNone(mission_date)
-            self.assertIsNone(name)
-            self.assertEqual(
-                log.output,
-                [
-                    "ERROR:root:Folder name '2024.13.30_test' does not match the expected format (YYYY.MM.DD_missionname)."
-                ],
             )
 
 
 class AddMissionTests(TestCase):
     def setUp(self):
-        # disable logging
         self.logger = logging.getLogger()
         self.logger.disabled = True
 
     def tearDown(self):
-        # reenable logging
         self.logger.disabled = False
 
-    def test_add_mission_from_folder(self):
-        add_mission_from_folder("2024.12.02_test_add_mission")
+    def test_add_mission_success(self):
+        add_mission_from_folder("2024.12.02_test_mission")
         self.assertTrue(
-            Mission.objects.filter(name="test_add_mission", date="2024-12-02").exists()
+            Mission.objects.filter(name="test_mission", date="2024-12-02").exists()
         )
-        add_mission_from_folder(
-            "2024.12.02_test_add_mission_2", "TestLocation", "other info"
-        )
-        self.assertTrue(
-            Mission.objects.filter(
-                name="test_add_mission_2",
-                date="2024-12-02",
-                location="TestLocation",
-                notes="other info",
-            ).exists()
-        )
+
+    
 
 
 class AddDetailsTests(TestCase):
     def setUp(self):
-        AddFolderCommand.storage = InMemoryStorage()
-        self.test_storage = AddFolderCommand.storage
+        SyncCommand.storage = InMemoryStorage()
+        self.test_storage = SyncCommand.storage
 
-        # create fake files
-        mcap_file = ContentFile("123")
-        yaml_file = ContentFile(
-            "rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 14694379191"
+        # Fake files
+        self.test_storage.save("2024.12.02_mission1/test/bag/bag.mcap", ContentFile("123"))
+        self.test_storage.save(
+            "2024.12.02_mission1/test/bag/metadata.yaml",
+            ContentFile("rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 14694379191"),
         )
-        self.test_storage.save("2024.12.02_mission1/test/bag/bag.mcap", mcap_file)
-        self.test_storage.save("2024.12.02_mission1/test/bag/metadata.yaml", yaml_file)
 
-        # disable logging
         self.logger = logging.getLogger()
         self.logger.disabled = True
 
-    def _delete_recursive(self, path: str):
-        dirs, files = self.test_storage.listdir(path)
-        for dir in dirs:
-            self._delete_recursive(os.path.join(path, dir))
-        for file in files:
-            self.test_storage.delete(os.path.join(path, file))
-        if path:
-            self.test_storage.delete(path)
-
     def tearDown(self):
-        self._delete_recursive("")
-
-        # reenable logging
         self.logger.disabled = False
 
-    def test_add_details(self):
+    def test_add_mission_with_files(self):
         add_mission_from_folder("2024.12.02_mission1")
-        file = File.objects.filter(file="2024.12.02_mission1/test/bag/bag.mcap")
-        self.assertTrue(file.exists())
-        self.assertEqual(len(file), 1)
-        self.assertEqual(file.first().size, 3)
-        self.assertEqual(file.first().duration, 14)
-
-        mission_files = Mission_files.objects.filter(mission__name="mission1")
-        self.assertTrue(mission_files.exists())
-        self.assertEqual(len(mission_files), 1)
-        self.assertEqual(mission_files.first().file, file.first())
-        self.assertEqual(mission_files.first().type, "test")
-
-
-class BasicTests(TestCase):
-    def test_extract_info_from_folder(self):
-        mission_date, name = extract_info_from_folder("2024.11.30_test")
-        self.assertEqual(
-            mission_date, datetime.strptime("2024.11.30", "%Y.%m.%d").date()
-        )
-        self.assertEqual(name, "test")
+        self.assertTrue(File.objects.exists())
+        self.assertTrue(Mission_files.objects.exists())

--- a/backend/cli_commands/test_add_folder.py
+++ b/backend/cli_commands/test_add_folder.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from django.test import TestCase
 import cli_commands.SyncCommand as SyncCommand
 from restapi.models import Mission, File, Mission_files

--- a/backend/cli_commands/test_add_folder.py
+++ b/backend/cli_commands/test_add_folder.py
@@ -32,8 +32,6 @@ class AddMissionTests(TestCase):
             Mission.objects.filter(name="test_mission", date="2024-12-02").exists()
         )
 
-    
-
 
 class AddDetailsTests(TestCase):
     def setUp(self):
@@ -41,10 +39,14 @@ class AddDetailsTests(TestCase):
         self.test_storage = SyncCommand.storage
 
         # Fake files
-        self.test_storage.save("2024.12.02_mission1/test/bag/bag.mcap", ContentFile("123"))
+        self.test_storage.save(
+            "2024.12.02_mission1/test/bag/bag.mcap", ContentFile("123")
+        )
         self.test_storage.save(
             "2024.12.02_mission1/test/bag/metadata.yaml",
-            ContentFile("rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 14694379191"),
+            ContentFile(
+                "rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 14694379191"
+            ),
         )
 
         self.logger = logging.getLogger()

--- a/backend/cli_commands/test_sync_folder.py
+++ b/backend/cli_commands/test_sync_folder.py
@@ -54,10 +54,10 @@ class SyncFolderArgumentTests(TestCase):
 
         # Verify add_mission_from_folder is called with correct arguments
         self.mock_add_mission_from_folder.assert_any_call(
-            "2024.12.02_mission1", None, None
+            "2024.12.02_mission1"
         )
         self.mock_add_mission_from_folder.assert_any_call(
-            "2024.12.03_mission2", None, None
+            "2024.12.03_mission2"
         )
         # Ensure add_mission_from_folder is not called for invalid folders
         self.assertEqual(self.mock_add_mission_from_folder.call_count, 2)

--- a/backend/cli_commands/test_sync_folder.py
+++ b/backend/cli_commands/test_sync_folder.py
@@ -53,11 +53,7 @@ class SyncFolderArgumentTests(TestCase):
         sync_folder()
 
         # Verify add_mission_from_folder is called with correct arguments
-        self.mock_add_mission_from_folder.assert_any_call(
-            "2024.12.02_mission1"
-        )
-        self.mock_add_mission_from_folder.assert_any_call(
-            "2024.12.03_mission2"
-        )
+        self.mock_add_mission_from_folder.assert_any_call("2024.12.02_mission1")
+        self.mock_add_mission_from_folder.assert_any_call("2024.12.03_mission2")
         # Ensure add_mission_from_folder is not called for invalid folders
         self.assertEqual(self.mock_add_mission_from_folder.call_count, 2)

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -1,9 +1,9 @@
 from django.test import TestCase
 from datetime import date
+import cli_commands.SyncCommand as SyncCommand
 from restapi.models import Mission, Tag
 from restapi.serializer import MissionSerializer
 from cli_commands.Command import Command
-import cli_commands.AddFolderCommand as AddFolderCommand
 import cli
 from io import StringIO
 import sys
@@ -158,12 +158,12 @@ class MainFunctionTests(TestCase):
 
 class FakeFileSystemTests(TestCase):
     def setUp(self):
-        AddFolderCommand.storage = InMemoryStorage()
-        self.test_storage = AddFolderCommand.storage
+        SyncCommand.storage = InMemoryStorage()
+        self.test_storage = SyncCommand.storage
 
         # create fake files
         empty_file = ContentFile("")
-        self.test_storage.save("2024.12.02_test/some_file", empty_file)
+        self.test_storage.save("2024.12.02_testmission/test/bag", empty_file)
 
     def _delete_recursive(self, path: str):
         dirs, files = self.test_storage.listdir(path)
@@ -178,13 +178,14 @@ class FakeFileSystemTests(TestCase):
         self._delete_recursive("")
 
     def test_addfolder(self):
-        args = ["addfolder", "--path", "2024.12.02_test"]
+        args = [
+            "addfolder",
+            "--path",
+            "2024.12.02_testmission",
+        ]
         with self.assertLogs(level="INFO") as log:
             cli.main(args)
             self.assertTrue(
-                Mission.objects.filter(name="test", date="2024-12-02").exists()
+                Mission.objects.filter(name="testmission", date="2024-12-02").exists()
             )
-            self.assertEqual(
-                log.output,
-                ["INFO:root:Mission 'test' from folder '2024.12.02_test' added."],
-            )
+            self.assertEqual(log.output, ["INFO:root:Mission 'testmission' added successfully."])

--- a/backend/tests_cli.py
+++ b/backend/tests_cli.py
@@ -188,4 +188,6 @@ class FakeFileSystemTests(TestCase):
             self.assertTrue(
                 Mission.objects.filter(name="testmission", date="2024-12-02").exists()
             )
-            self.assertEqual(log.output, ["INFO:root:Mission 'testmission' added successfully."])
+            self.assertEqual(
+                log.output, ["INFO:root:Mission 'testmission' added successfully."]
+            )


### PR DESCRIPTION
resolves #108 

# Changes
- First I refactored the add folder command since it used a lot of helper functions and it was hard to understand what is going on. the add folder class now only has one add_mission_from_folder function. This function uses the new sync_mcap_files function (located in SyncCommand.py) to add the Files for the mission
- The sync_mcap_files function adds Files and their details to the database if they are not in the database yet and it removes Files and their details from the database if they are not in the filesystem anymore
- I added a custom logging handler that tracks if any log message was emitted during the sync_folder command. If no log was emitted, that means that nothing was changed/synced. Therefore the sync command now has a message that tells the user that nothing was synced.

# Note
During refactoring I noticed that we use the yaml file to extract data. In the future we want all extraction to happen from the mcap file. But that is something for another Issue