### PR TITLE
Sync files

### DIFF
--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -40,7 +40,7 @@ def sync_files(mission_path, mission):
     - Removes files from the database if they are missing.
     """
 
-    existing_files = {file.file for file in File.objects.filter(mission_id=mission.id)}
+    existing_files = {file.file.name for file in File.objects.filter(mission=mission)}
     current_files = set()
 
     # Find all .mcap and metadata files from the mission in the filesystem

--- a/backend/cli_commands/SyncCommand.py
+++ b/backend/cli_commands/SyncCommand.py
@@ -170,5 +170,5 @@ def sync_folder():
                 f"Saved metadata for mission '{mission.name}' to the mission folder"
             )
     if not log_tracker.log_occurred:
-        logging.info("No changes detected.")
+        logging.info("Nothing was modified, no new metadata was saved")
     logger.removeHandler(log_tracker)

--- a/backend/cli_commands/test_sync_folder.py
+++ b/backend/cli_commands/test_sync_folder.py
@@ -2,7 +2,8 @@ import logging
 import os
 from django.test import TestCase
 from unittest.mock import patch
-from cli_commands.SyncCommand import sync_folder
+from restapi.models import File, Mission
+from cli_commands.SyncCommand import sync_folder, sync_files
 import cli_commands.SyncCommand as SyncCommand
 from django.core.files.base import ContentFile
 from django.core.files.storage.memory import InMemoryStorage
@@ -66,3 +67,71 @@ class SyncFolderArgumentTests(TestCase):
         )
         # Ensure add_mission_from_folder is not called for invalid folders
         self.assertEqual(self.mock_add_mission_from_folder.call_count, 2)
+
+class SyncFilesTests(TestCase):
+    def setUp(self):
+        SyncCommand.storage = InMemoryStorage()
+        self.test_storage = SyncCommand.storage
+
+        # create fake files
+        empty_file = ContentFile("")
+        yaml_file = ContentFile(
+            "rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 14694379191"
+        )
+        self.test_storage.save("2024.12.02_mission1/test/bag/bag.mcap", empty_file)
+        self.test_storage.save("2024.12.02_mission1/test/bag/metadata.yaml", yaml_file)
+
+        self.mission = Mission.objects.create(
+            name="mission1", date="2024-12-02", location="test_location"
+        )
+
+        self.logger = logging.getLogger()
+        self.logger.disabled = True
+
+    def tearDown(self):
+        self._delete_recursive("")
+        self.logger.disabled = False
+
+    def _delete_recursive(self, path: str):
+        dirs, files = self.test_storage.listdir(path)
+        for dir in dirs:
+            self._delete_recursive(os.path.join(path, dir))
+        for file in files:
+            self.test_storage.delete(os.path.join(path, file))
+        if path:
+            self.test_storage.delete(path)
+
+    def test_sync_files_adds_new_files(self):
+        """
+        Test sync_files to ensure new files are added to the database.
+        """
+        sync_files("2024.12.02_mission1", self.mission)
+        files = File.objects.filter(mission_id=self.mission.id)
+        self.assertEqual(files.count(), 1)
+        self.assertEqual(files.first().file, "2024.12.02_mission1/test/bag/bag.mcap")
+
+    def test_sync_files_removes_missing_files(self):
+        """
+        Test sync_files to ensure missing files are removed from the database.
+        """
+        # Add a file to the database that doesn't exist in the filesystem
+        File.objects.create(
+            file="2024.12.02_mission1/test/bag/missing.mcap",
+            mission_id=self.mission.id,
+            type="test",
+            duration=10000000000,
+            size=369629523,
+        )
+        sync_files("2024.12.02_mission1", self.mission)
+        files = File.objects.filter(mission_id=self.mission.id)
+        self.assertEqual(files.count(), 1)
+        self.assertEqual(files.first().file, "2024.12.02_mission1/test/bag/bag.mcap")
+
+    def test_sync_files_handles_exceptions(self):
+        """
+        Test sync_files to ensure it handles exceptions gracefully.
+        """
+        with patch("cli_commands.SyncCommand.storage.size", side_effect=Exception("Test exception")):
+            sync_files("2024.12.02_mission1", self.mission)
+            files = File.objects.filter(mission_id=self.mission.id)
+            self.assertEqual(files.count(), 0)

--- a/backend/cli_commands/test_sync_folder.py
+++ b/backend/cli_commands/test_sync_folder.py
@@ -68,6 +68,7 @@ class SyncFolderArgumentTests(TestCase):
         # Ensure add_mission_from_folder is not called for invalid folders
         self.assertEqual(self.mock_add_mission_from_folder.call_count, 2)
 
+
 class SyncFilesTests(TestCase):
     def setUp(self):
         SyncCommand.storage = InMemoryStorage()
@@ -131,7 +132,10 @@ class SyncFilesTests(TestCase):
         """
         Test sync_files to ensure it handles exceptions gracefully.
         """
-        with patch("cli_commands.SyncCommand.storage.size", side_effect=Exception("Test exception")):
+        with patch(
+            "cli_commands.SyncCommand.storage.size",
+            side_effect=Exception("Test exception"),
+        ):
             sync_files("2024.12.02_mission1", self.mission)
             files = File.objects.filter(mission_id=self.mission.id)
             self.assertEqual(files.count(), 0)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ numpy
 opencv-python
 moviepy
 dj-rest-auth==7.*
+mcap

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,4 +16,3 @@ numpy
 opencv-python
 moviepy
 dj-rest-auth==7.*
-mcap

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -165,7 +165,8 @@ Arguments:
 - `--path` path to mission folder of format `YYYY.MM.DD_mission_name` without trailing /
 
 ### `cli.py sync`
-adds all missions from a folder not currently in the database and deletes all missions from the database that are not in the folder\
+adds all missions from a folder not currently in the database and deletes all missions from the database that are not in the folder.\
+It also scans if mcap files were deleted or added and updates the database accordingly.\
 The folder that is searched for mission folders is the root of the Default Storage as configured in [settings.py](../../backend/backend/settings.py)
 
 ### `cli.py tag`


### PR DESCRIPTION
resolves #108 

# Changes
- The sync_files function adds Files and their details to the database if they are not in the database yet and it removes Files and their details from the database if they are not in the filesystem anymore
- I added a custom logging handler that tracks if any log message was emitted during the sync_folder command. If no log was emitted, that means that nothing was changed/synced. Therefore the sync command now has a message that tells the user that nothing was synced.

# Note
During refactoring I noticed that we use the yaml file to extract data. In the future we want all extraction to happen from the mcap file. But that is something for another Issue