### PR TITLE
FetchAPI - Topics

### DIFF
--- a/docs/fetchapi/README.md
+++ b/docs/fetchapi/README.md
@@ -103,6 +103,30 @@ The `fetchapi.ts` file provides utility functions to interact with the Mission D
 - **Parameters**: `missionID` (number)
 - **Returns**: `Promise<{ string }> (formatted)`
 - **Endpoint**: `GET /restapi/missions/{missionID}/files/`
+
+### getTopicsByFile(file_path)
+- Fetches all topics associated with a specific file.
+- **Parameters**: `file_path` (string)
+- **Returns**: `Promise<Topic[]>`
+- **Endpoint**: `GET /topics/{file_path}`
+
+### getAllowedTopics()
+- Fetches all allowed topic names.
+- **Returns**: `Promise<Topic[]>`
+- **Endpoint**: `GET /topics-names`
+
+### createAllowedTopic(topic_name)
+- Creates a new allowed topic.
+- **Parameters**: `topic_name` (string)
+- **Returns**: `Promise<Topic>`
+- **Endpoint**: `POST /topics-names/create`
+
+### deleteAllowedTopic(topic_name)
+- Deletes an allowed topic by its name.
+- **Parameters**: `topic_name` (string)
+- **Returns**: `Promise<string>`
+- **Endpoint**: `DELETE /topics-names/{topic_name}`
+
 -------------------------
 ## Configuration
 - **`FETCH_API_BASE_URL`**: The base URL for API requests, defined in `config.tsx`. Set to: `http://127.0.0.1:8000/restapi`

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -38,6 +38,16 @@ export interface RenderedMission {
   tags: Tag[];
 }
 
+//Topic
+export interface Topic {
+  id: number;
+  file: string;
+  name: string;
+  type: string;
+  message_count: number;
+  frequency: number;
+}
+
 //User interface
 export interface User {
   id: number;

--- a/frontend/app/fetchapi/tests/topics.test.tsx
+++ b/frontend/app/fetchapi/tests/topics.test.tsx
@@ -1,0 +1,121 @@
+import { getTopicsByFile, getAllowedTopics, createAllowedTopic, deleteAllowedTopic } from '../topics';
+import { FETCH_API_BASE_URL } from '~/config';
+import { getHeaders } from '../headers';
+
+/*
+How to run the tests:
+- cd to frontend directory
+- run `npm test`
+*/
+
+// Mock fetch and global objects
+global.fetch = jest.fn();
+global.console = { ...console, error: jest.fn() };
+
+describe("Fetch API Functions", () => {
+    beforeEach(() => {
+        (fetch as jest.Mock).mockClear();
+        (console.error as jest.Mock).mockClear();
+    });
+
+    describe("Topics Fetch Functions", () => {
+        test("getTopicsByFile should fetch topics of a file successfully", async () => {
+            const mockResponse = [{ id: 1, name: 'Topic 1' }];
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValueOnce(mockResponse),
+            });
+
+            const result = await getTopicsByFile('file_path');
+            expect(result).toEqual(mockResponse);
+            expect(fetch).toHaveBeenCalledWith(`${FETCH_API_BASE_URL}/topics/file_path`, {
+                method: 'GET',
+                credentials: 'include',
+                headers: getHeaders(),
+            });
+        });
+
+        test("getTopicsByFile should throw an error if fetching topics fails", async () => {
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            });
+
+            await expect(getTopicsByFile('file_path')).rejects.toThrow('Error 404: Failed to fetch topics of file file_path');
+        });
+
+        test("getAllowedTopics should fetch allowed topics successfully", async () => {
+            const mockResponse = [{ id: 1, name: 'Allowed Topic 1' }];
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValueOnce(mockResponse),
+            });
+
+            const result = await getAllowedTopics();
+            expect(result).toEqual(mockResponse);
+            expect(fetch).toHaveBeenCalledWith(`${FETCH_API_BASE_URL}/topics-names`, {
+                method: 'GET',
+                credentials: 'include',
+                headers: getHeaders(),
+            });
+        });
+
+        test("getAllowedTopics should throw an error if fetching allowed topics fails", async () => {
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            });
+
+            await expect(getAllowedTopics()).rejects.toThrow('Error 404: Failed to fetch allowed topics');
+        });
+
+        test("createAllowedTopic should create a new allowed topic successfully", async () => {
+            const mockResponse = { id: 1, name: 'New Topic' };
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValueOnce(mockResponse),
+            });
+
+            const result = await createAllowedTopic('New Topic');
+            expect(result).toEqual(mockResponse);
+            expect(fetch).toHaveBeenCalledWith(`${FETCH_API_BASE_URL}/topics-names/create`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: getHeaders(),
+                body: JSON.stringify({ topic_name: 'New Topic' }),
+            });
+        });
+
+        test("createAllowedTopic should throw an error if creating a new topic fails", async () => {
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 400,
+            });
+
+            await expect(createAllowedTopic('New Topic')).rejects.toThrow('Error 400: Failed to create topic New Topic');
+        });
+
+        test("deleteAllowedTopic should delete an allowed topic successfully", async () => {
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+            });
+
+            const result = await deleteAllowedTopic('Topic to Delete');
+            expect(result).toBe('Topic Topic to Delete successfully deleted from allowed topics');
+            expect(fetch).toHaveBeenCalledWith(`${FETCH_API_BASE_URL}/topics-names/Topic to Delete`, {
+                method: 'DELETE',
+                credentials: 'include',
+                headers: getHeaders(),
+            });
+        });
+
+        test("deleteAllowedTopic should throw an error if deleting a topic fails", async () => {
+            (fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            });
+
+            await expect(deleteAllowedTopic('Topic to Delete')).rejects.toThrow('Error 404: Failed to delete topic Topic to Delete');
+        });
+    });
+});

--- a/frontend/app/fetchapi/topics.tsx
+++ b/frontend/app/fetchapi/topics.tsx
@@ -43,7 +43,7 @@ export const createAllowedTopic = async (topic_name: string): Promise<Topic> => 
   };
 
 // Function to delete an allowed topic by name
-export const deleteAllowedTopic = async (topic_name: string): Promise<void> => {
+export const deleteAllowedTopic = async (topic_name: string): Promise<string> => {
     const response = await fetch(`${FETCH_API_BASE_URL}/topics-names/${topic_name}`, {
       method: "DELETE",
       credentials: "include",
@@ -52,4 +52,5 @@ export const deleteAllowedTopic = async (topic_name: string): Promise<void> => {
     if (!response.ok) {
       throw new Error(`Error ${response.status}: Failed to delete topic ${topic_name}`);
     }
+    return `Topic ${topic_name} successfully deleted from allowed topics`;
   };

--- a/frontend/app/fetchapi/topics.tsx
+++ b/frontend/app/fetchapi/topics.tsx
@@ -1,0 +1,55 @@
+import { Topic } from "~/data";
+import { FETCH_API_BASE_URL } from "~/config";
+import { getHeaders } from "./headers";
+
+// Function to fetch all topics of a file
+export const getTopicsByFile = async (file_path: string): Promise<Topic[]> => {
+  const response = await fetch(`${FETCH_API_BASE_URL}/topics/${file_path}`, {
+    method: "GET",
+    credentials: "include",
+    headers: getHeaders(),
+  });
+  if (!response.ok) {
+    throw new Error(`Error ${response.status}: Failed to fetch topics of file ${file_path}`);
+  }
+  return response.json();
+};
+
+// Function to fetch all allowed topic names
+export const getAllowedTopics = async (): Promise<Topic[]> => {
+    const response = await fetch(`${FETCH_API_BASE_URL}/topics-names`, {
+      method: "GET",
+      credentials: "include",
+      headers: getHeaders(),
+    });
+    if (!response.ok) {
+      throw new Error(`Error ${response.status}: Failed to fetch allowed topics`);
+    }
+    return response.json();
+  };
+
+// Function to create a new allowed topic
+export const createAllowedTopic = async (topic_name: string): Promise<Topic> => {
+    const response = await fetch(`${FETCH_API_BASE_URL}/topics-names/create`, {
+      method: "POST",
+      credentials: "include",
+      headers: getHeaders(),
+      body: JSON.stringify({ topic_name }),
+    });
+    if (!response.ok) {
+      throw new Error(`Error ${response.status}: Failed to create topic ${topic_name}`);
+    }
+    return response.json();
+  };
+
+// Function to delete an allowed topic by name
+export const deleteAllowedTopic = async (topic_name: string): Promise<void> => {
+    const response = await fetch(`${FETCH_API_BASE_URL}/topics-names/${topic_name}`, {
+      method: "DELETE",
+      credentials: "include",
+      headers: getHeaders(),
+    });
+    if (!response.ok) {
+      throw new Error(`Error ${response.status}: Failed to delete topic ${topic_name}`);
+    }
+  };


### PR DESCRIPTION
Resolves Issue #167 
#
This PR adds functionality to fetch topics
## Changes:
- ### getTopicsByFile:  
Parameter: path to the file
Return: List of topics in the file | Error message
- ### getAllowedTopics: 
Parameter: None 
Return: List of all allowed topics | Error message
- ### createAllowedTopic: 
Parameter: name of the topic 
Return: The created topic | Error message
- ### deleteAllowedTopic: 
Parameter: name of the topic 
Return: Success response | Error message
### Interface `Topic` in data.tsx
### Tests for the new functions:
- [frontend/app/fetchapi/tests/topics.test.tsx](frontend/app/fetchapi/tests/topics.test.tsx)
### Documentation for the new functions:
- [docs/fetchapi](docs/fetchapi)
## Testing
- `cd` into frontend directory
- `npm install`
- `npm test`
