### PR TITLE
Frontend embed mp4 video

### DIFF
--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -20,7 +20,7 @@ class MissionWasModifiedSerializer(serializers.ModelSerializer):
 
 class FileSerializer(serializers.ModelSerializer):
     file_path = serializers.CharField(source="file.path", initial=None)
-    video_path = serializers.CharField(source="video.path", initial=None)
+    video_path = serializers.SerializerMethodField()
     file_url = serializers.SerializerMethodField()
     video_url = serializers.SerializerMethodField()
 
@@ -54,6 +54,11 @@ class FileSerializer(serializers.ModelSerializer):
         if sessionid and obj.video:
             url = f"{obj.video.url.replace('/download/', '/stream/')}?sessionid={sessionid}"
             return url
+        return None
+
+    def get_video_path(self, obj):
+        if obj.video:
+            return obj.video.path
         return None
 
 

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -20,6 +20,7 @@ class MissionWasModifiedSerializer(serializers.ModelSerializer):
 
 class FileSerializer(serializers.ModelSerializer):
     file_path = serializers.CharField(source="file.path", initial=None)
+    video_path = serializers.CharField(source="video.path", initial=None)
     file_url = serializers.SerializerMethodField()
     video_url = serializers.SerializerMethodField()
 
@@ -29,7 +30,7 @@ class FileSerializer(serializers.ModelSerializer):
             "id",
             "file_path",
             "file_url",
-            "video",
+            "video_path",
             "video_url",
             "robot",
             "duration",

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -69,4 +69,5 @@ export interface FileData {
   duration: string;
   size: string;
   robot: string;
+  type: string;
 }

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -66,7 +66,7 @@ export interface FileData {
   fileUrl: URL;
   videoPath: string;
   videoUrl: URL;
-  duration: number;
-  size: number;
+  duration: string;
+  size: string;
   robot: string;
 }

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -50,7 +50,7 @@ export interface User {
 
 //Converts a rendered mission to mission data
 export function convertToMissionData(
-  renderedMission: RenderedMission
+  renderedMission: RenderedMission,
 ): MissionData {
   return {
     id: renderedMission.id,
@@ -59,4 +59,14 @@ export function convertToMissionData(
     date: renderedMission.date,
     notes: renderedMission.notes,
   };
+}
+
+export interface FileData {
+  filePath: string;
+  fileUrl: URL;
+  videoPath: string;
+  videoUrl: URL;
+  duration: number;
+  size: number;
+  robot: string;
 }

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -111,11 +111,12 @@ export const getFileData = async (filePath: string): Promise<FileData> => {
 
   return {
     filePath: data.file_path,
-    fileUrl: data.file_url,
+    fileUrl: new URL(data.file_url),
     videoPath: data.video_path,
-    videoUrl: data.video_url,
+    videoUrl: new URL(data.video_url),
     duration: transformDurations([data.duration])[0],
     size: transformSizes([data.size])[0],
     robot: data.robot,
+    type: data.type,
   };
 };

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -1,9 +1,8 @@
-import { DetailViewData } from "~/data";
+import { DetailViewData, FileData } from "~/data";
 import { FETCH_API_BASE_URL } from "~/config";
 import { getHeaders } from "./headers";
 import { transformDurations, transformSizes } from "~/utilities/FormatHandler";
 
-// Get details by mission
 export const getDetailsByMission = async (
   missionId: number,
 ): Promise<DetailViewData> => {
@@ -88,4 +87,35 @@ export const getRobotNames = async (missionId: number): Promise<string[]> => {
   const details = await getDetailsByMission(missionId);
 
   return details.robots;
+};
+
+/**
+ * Get details about a file by path
+ * @param filePath file path
+ * @returns FileData
+ */
+export const getFileData = async (filePath: string): Promise<FileData> => {
+  const response = await fetch(`${FETCH_API_BASE_URL}/file/${filePath}`, {
+    method: "GET",
+    credentials: "include",
+    headers: getHeaders(),
+  });
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error((await response.json()).details);
+    }
+    throw new Error(`Failed to fetch details for file ${filePath}`);
+  }
+
+  const data = await response.json();
+
+  return {
+    filePath: data.file_path,
+    fileUrl: data.file_url,
+    videoPath: data.video_path,
+    videoUrl: data.video_url,
+    duration: data.duration,
+    size: data.size,
+    robot: data.robot,
+  };
 };

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -102,7 +102,7 @@ export const getFileData = async (filePath: string): Promise<FileData> => {
   });
   if (!response.ok) {
     if (response.status === 404) {
-      throw new Error((await response.json()).details);
+      throw new Error((await response.json()).detail);
     }
     throw new Error(`Failed to fetch details for file ${filePath}`);
   }
@@ -114,8 +114,8 @@ export const getFileData = async (filePath: string): Promise<FileData> => {
     fileUrl: data.file_url,
     videoPath: data.video_path,
     videoUrl: data.video_url,
-    duration: data.duration,
-    size: data.size,
+    duration: transformDurations([data.duration])[0],
+    size: transformSizes([data.size])[0],
     robot: data.robot,
   };
 };

--- a/frontend/app/fetchapi/tests/details.test.tsx
+++ b/frontend/app/fetchapi/tests/details.test.tsx
@@ -1,11 +1,12 @@
 import { FETCH_API_BASE_URL } from "~/config";
-import { DetailViewData } from "~/data";
+import { DetailViewData, FileData } from "~/data";
 import {
   getDetailsByMission,
   getFormattedDetails,
   getRobotNames,
   getTotalDuration,
   getTotalSize,
+  getFileData,
 } from "../details";
 
 /*
@@ -205,6 +206,46 @@ describe("Fetch API Functions", () => {
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,
+        {
+          method: "GET",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    test("getFileData should fetch data of a file", async () => {
+      const mockResponse = {
+        file_path: "file1.mcap",
+        file_url: "http://example.com/file/download/file1.mcap",
+        video_path: "file1.mp4",
+        video_url: "http://example.com/file/stream/file1.mcap",
+        duration: "60",
+        size: "1024",
+        robot: "hihi",
+        type: "test",
+      };
+
+      const expectedResponse: FileData = {
+        filePath: "file1.mcap",
+        fileUrl: new URL("http://example.com/file/download/file1.mcap"),
+        videoPath: "file1.mp4",
+        videoUrl: new URL("http://example.com/file/stream/file1.mcap"),
+        duration: "00:01:00",
+        size: "1.00 KB",
+        robot: "hihi",
+        type: "test",
+      };
+
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const details = await getFileData("file1.mcap");
+      expect(details).toEqual(expectedResponse);
+      expect(fetch).toHaveBeenCalledWith(
+        `${FETCH_API_BASE_URL}/file/file1.mcap`,
         {
           method: "GET",
           credentials: "include",

--- a/frontend/app/pages/dataset/DatasetView.tsx
+++ b/frontend/app/pages/dataset/DatasetView.tsx
@@ -19,11 +19,19 @@ export function DatasetView(data: DatasetViewProps) {
         <div>
           <Text size="lg">File: {data.file}</Text>
           <Text size="lg">
-            File download: <a href={String(data.fileUrl)}>download</a>
+            File download: <a href={String(data.fileUrl)}>download</a>{" "}
+            <a
+              href={
+                "foxglove://open?ds=remote-file&ds.url=" + String(data.fileUrl)
+              }
+            >
+              open in Foxglove
+            </a>
           </Text>
           <Text size="lg">Duration: {data.duration}</Text>
           <Text size="lg">Size: {data.size}</Text>
           <Text size="lg">Robot: {data.robot}</Text>
+          <Text size="lg">Video:</Text>
           {data.video ? (
             <iframe
               width="320"

--- a/frontend/app/pages/dataset/DatasetView.tsx
+++ b/frontend/app/pages/dataset/DatasetView.tsx
@@ -4,18 +4,32 @@ import AbstractPage from "../AbstractPage";
 // Interface describing expected properties of DatasetView
 interface DatasetViewProps {
   file: string | null;
-  duration: string | null;
-  size: string | null;
+  fileUrl: URL | null;
+  video: string | null;
+  videoUrl: URL | null;
+  duration: number | null;
+  size: number | null;
+  robot: string | null;
 }
 
-export function DatasetView({ file, duration, size }: DatasetViewProps) {
+export function DatasetView(data: DatasetViewProps) {
   return (
     <AbstractPage headline="Dataset View">
-      {file !== null ? (
+      {data.file !== null ? (
         <div>
-          <Text size="lg">File: {file}</Text>
-          <Text size="lg">Duration: {duration}</Text>
-          <Text size="lg">Size: {size}</Text>
+          <Text size="lg">File: {data.file}</Text>
+          <Text size="lg">
+            File download: <a href={String(data.fileUrl)}>download</a>
+          </Text>
+          <Text size="lg">Duration: {data.duration}</Text>
+          <Text size="lg">Size: {data.size}</Text>
+          <Text size="lg">Robot: {data.robot}</Text>
+          <iframe
+            width="320"
+            height="320"
+            src={String(data.videoUrl)}
+            allowFullScreen
+          ></iframe>
         </div>
       ) : (
         <Text>No data available</Text>

--- a/frontend/app/pages/dataset/DatasetView.tsx
+++ b/frontend/app/pages/dataset/DatasetView.tsx
@@ -7,8 +7,8 @@ interface DatasetViewProps {
   fileUrl: URL | null;
   video: string | null;
   videoUrl: URL | null;
-  duration: number | null;
-  size: number | null;
+  duration: string | null;
+  size: string | null;
   robot: string | null;
 }
 
@@ -24,12 +24,16 @@ export function DatasetView(data: DatasetViewProps) {
           <Text size="lg">Duration: {data.duration}</Text>
           <Text size="lg">Size: {data.size}</Text>
           <Text size="lg">Robot: {data.robot}</Text>
-          <iframe
-            width="320"
-            height="320"
-            src={String(data.videoUrl)}
-            allowFullScreen
-          ></iframe>
+          {data.video ? (
+            <iframe
+              width="320"
+              height="320"
+              src={String(data.videoUrl)}
+              allowFullScreen
+            ></iframe>
+          ) : (
+            <Text size="lg">No video available</Text>
+          )}
         </div>
       ) : (
         <Text>No data available</Text>

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -3,7 +3,7 @@ import { DetailViewData } from "~/data";
 import { useNavigate } from "@remix-run/react";
 import { IconClipboard } from "@tabler/icons-react";
 import { useClipboard } from "@mantine/hooks";
-import { notifications } from '@mantine/notifications';
+import { notifications } from "@mantine/notifications";
 
 export function ShowDatasets({
   data,
@@ -14,19 +14,15 @@ export function ShowDatasets({
 }) {
   const navigate = useNavigate();
   const clipboard = useClipboard({ timeout: 500 });
-  
+  const missionPathSplitted: string[] = basePath.split("/").slice(-2, -1);
+
   // Creates rows of table
   const rows = data.files.map((file, index) => (
     <Table.Tr
       key={file}
       onClick={() =>
         navigate(
-          "/dataset?fileName=" +
-            file +
-            "&duration=" +
-            data.durations[index] +
-            "&size=" +
-            data.sizes[index]
+          "/dataset?fileName=" + missionPathSplitted.concat(file).join("/"),
         )
       }
       // Change color on mouse hover
@@ -43,16 +39,15 @@ export function ShowDatasets({
           onClick={(e) => {
             e.stopPropagation();
             clipboard.copy(basePath + file);
-            
+
             notifications.clean();
 
             notifications.show({
-              title: 'Copied to clipboard!',
+              title: "Copied to clipboard!",
               message: basePath + file,
-              color: 'orange',
-              radius: 'md',
-            })
-
+              color: "orange",
+              radius: "md",
+            });
           }}
         >
           <ThemeIcon variant="white">

--- a/frontend/app/routes/dataset.tsx
+++ b/frontend/app/routes/dataset.tsx
@@ -1,13 +1,10 @@
 import { Skeleton } from "@mantine/core";
 import { LoaderFunctionArgs } from "@remix-run/node";
 import {
-  data,
   MetaFunction,
   redirect,
   useLoaderData,
-  useSearchParams,
 } from "@remix-run/react";
-import { stringify } from "postcss";
 import { useEffect, useState } from "react";
 import { FileData } from "~/data";
 import { getFileData } from "~/fetchapi/details";

--- a/frontend/app/routes/dataset.tsx
+++ b/frontend/app/routes/dataset.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from "@mantine/core";
 import { LoaderFunctionArgs } from "@remix-run/node";
 import {
   data,
@@ -6,6 +7,10 @@ import {
   useLoaderData,
   useSearchParams,
 } from "@remix-run/react";
+import { stringify } from "postcss";
+import { useEffect, useState } from "react";
+import { FileData } from "~/data";
+import { getFileData } from "~/fetchapi/details";
 import { CreateAppShell } from "~/layout/AppShell";
 import { DatasetView } from "~/pages/dataset/DatasetView";
 import { sessionStorage } from "~/utilities/LoginHandler";
@@ -22,10 +27,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   let url = new URL(request.url);
   const fileName = url.searchParams.get("fileName");
-  const duration = url.searchParams.get("duration");
-  const size = url.searchParams.get("size");
 
-  if (!fileName || !duration || !size)
+  if (!fileName)
     throw new Response(null, {
       status: 400,
       statusText: "Invalid URL",
@@ -33,16 +36,51 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return {
     fileName,
-    duration,
-    size,
   };
 }
 
 function Dataset() {
-  const { fileName, duration, size } = useLoaderData<typeof loader>();
+  const { fileName } = useLoaderData<typeof loader>();
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // File
+  const [fileData, setFileData] = useState<FileData>();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const file: FileData = await getFileData(fileName);
+        setFileData(file);
+      } catch (e: any) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError("An unknown error occurred during mission fetching");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [fileName]);
+
+  if (loading) return <Skeleton style={{ height: "30vh" }} />;
+  if (error) return <p>Error: {error}</p>;
+  if (!fileData) return <p>No data available</p>;
 
   return (
-    <DatasetView file={fileName} duration={duration} size={size}></DatasetView>
+    <DatasetView
+      file={fileData.filePath}
+      fileUrl={fileData.fileUrl}
+      video={fileData.videoPath}
+      videoUrl={fileData.videoUrl}
+      duration={fileData.duration}
+      size={fileData.size}
+      robot={fileData.robot}
+    ></DatasetView>
   );
 }
 


### PR DESCRIPTION
The video is now included in the Dataset View and can be watched there.

I had to change the Dataset View to not take everything as URL parameter but to actually fetch data from the backend to access more data.

I also included two simple links to either download the mcap file or open it in foxglove.

resolves #211 

The design of the Dataset View is currently not beautiful but that will be changed in another task.

## How to test
Extract a mp4 video of an mcap file with the `mcap_to_mp4.py` script (or any mp4 file) and put it in the backend/media/ folder (maybe in same subfolder as mcap file).\
Add the video to a mcap file with this:
```python
import os
import django
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
django.setup()
from restapi.models import File

file = File.objects.get(file="path/to/mcap")
file.video = "path/to/mp4"
file.save()
```
(replace `path/to/mcap` and `path/to/mp4` with the path inside the media folder)

Start the frontend and navigate to the dataset view of the file where you added the video. You should see the video start playing.