### PR TITLE
bugfix when mission name is long

### DIFF
--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -290,7 +290,11 @@ export function Overview() {
       onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#f1f3f5")}
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "")}
     >
-      <Table.Td>{row.name}</Table.Td>
+      <Table.Td>
+        <div style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>
+          {row.name}
+        </div>
+      </Table.Td>
       <Table.Td>
         <div style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>
           {truncateText(row.location, 42)}


### PR DESCRIPTION
When the mission name is long and the page is not wide enough it cuts into the location field like so:
![grafik](https://github.com/user-attachments/assets/deb4576f-6468-4f2e-b35a-2ebf5c54ef3e)
I made it so the text stays in its column
![grafik](https://github.com/user-attachments/assets/50f4d0ac-3073-4dff-aafb-e4c509ac7168)
