### PR TITLE
fix rename tag bug and error message bug

### DIFF
--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -77,7 +77,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
     newTagColor: string,
   ) => {
     // check if tag name already exists
-    if (tags.find((tag) => tag.name === newTagName) && tagName !== newTagName) {
+    if (allTags.find((tag) => tag.name === newTagName) && tagName !== newTagName) {
       setChangeTagNameError("This tag name is already in use");
       return;
     }
@@ -212,6 +212,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                     setEditedTagName(tag.name);
                     setChangedTagName(tag.name);
                     setNewColor(tag.color);
+                    setChangeTagNameError("");
+                    setChangeColorError("");
                   }}
                 >
                   {tag.name}


### PR DESCRIPTION
I noticed some things in the tag picker that don't work anymore for some reason and fixed it.

- When changing the name of a tag and the new name is already belonging to a tag that is belonging to another mission, there is an invalid request to the backend to change the name to a name that already exists.
I replaced "tags" with "allTags" to fix this. 

- Also I reset the error messages for the edit tag menu when opening it up because the error message didn't reset when closing the menu. But now it resets the error message correctly