### PR TITLE
Fix S3 does not support absolute paths

### DIFF
--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -19,7 +19,7 @@ class MissionWasModifiedSerializer(serializers.ModelSerializer):
 
 
 class FileSerializer(serializers.ModelSerializer):
-    file_path = serializers.CharField(source="file.path", initial=None)
+    file_path = serializers.CharField(source="file.name", initial=None)
     video_path = serializers.SerializerMethodField()
     file_url = serializers.SerializerMethodField()
     video_url = serializers.SerializerMethodField()
@@ -58,7 +58,7 @@ class FileSerializer(serializers.ModelSerializer):
 
     def get_video_path(self, obj):
         if obj.video:
-            return obj.video.path
+            return obj.video.name
         return None
 
 


### PR DESCRIPTION
When info about a file is requested in the restapi the file_path is obtained with `file.path` but when S3 storage is used it raises an NotImplementedError with the message : 
```
This backend doesn't support absolute paths.
```

I changed the `file.path` to `file.name` and `video.path` to `video.name`.

Now the returned path is not the absolute path to a file but only the path inside the `backend/media/` folder or inside the S3 bucket.

resolves #231 

## How to test
When using an S3 bucket it should now be possible again to fetch details about a file.