### PR TITLE
Fix frontend video_url null

### DIFF
--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -75,7 +75,7 @@ export interface FileData {
   filePath: string;
   fileUrl: URL;
   videoPath: string;
-  videoUrl: URL;
+  videoUrl: URL | null;
   duration: string;
   size: string;
   robot: string;

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -113,7 +113,7 @@ export const getFileData = async (filePath: string): Promise<FileData> => {
     filePath: data.file_path,
     fileUrl: new URL(data.file_url),
     videoPath: data.video_path,
-    videoUrl: new URL(data.video_url),
+    videoUrl: data.video_url ? new URL(data.video_url) : null,
     duration: transformDurations([data.duration])[0],
     size: transformSizes([data.size])[0],
     robot: data.robot,


### PR DESCRIPTION
resolves #232 

I added a simple check that sets the `videoUrl `in the frontend to `null` if `null` is returned from the backend.\
For that I also had to make `videoUrl` nullable.

## How to test
The Dataset View for a mcap file without a video should work again.