### PR TITLE
aggregate totalSize/Duration and robots in the backend 

### DIFF
--- a/backend/cli_commands/test_command.py
+++ b/backend/cli_commands/test_command.py
@@ -39,9 +39,9 @@ class TableTests(TestCase):
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
             "id│total_duration│total_size│robots│name│date│location│notes│was_modified\n"
             + "┼┼┼┼┼┼┼┼\n"
-            + f"{missions[0].id}│0│0│<QuerySet[]>│Test0│2024-12-02│None│None│False\n"
-            + f"{missions[1].id}│0│0│<QuerySet[]>│Test1│2024-12-02│None│None│False\n"
-            + f"{missions[2].id}│0│0│<QuerySet[]>│Test2│2024-12-02│None│None│False",
+            + f"{missions[0].id}│0│0││Test0│2024-12-02│None│None│False\n"
+            + f"{missions[1].id}│0│0││Test1│2024-12-02│None│None│False\n"
+            + f"{missions[2].id}│0│0││Test2│2024-12-02│None│None│False",
         )
 
     def test_print_tag_table(self):
@@ -71,7 +71,7 @@ class TableTests(TestCase):
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
             "id│total_duration│total_size│robots│name│date│location│notes│was_modified\n"
             + "┼┼┼┼┼┼┼┼\n"
-            + f"{mission[0].id}│0│0│<QuerySet[]>│Test│2024-12-26│None│Test│False\n"
+            + f"{mission[0].id}│0│0││Test│2024-12-26│None│Test│False\n"
             + "││││linebreak│││with│\n"
             + "│││││││newline│",
         )

--- a/backend/cli_commands/test_command.py
+++ b/backend/cli_commands/test_command.py
@@ -37,11 +37,11 @@ class TableTests(TestCase):
         sys.stdout.flush()
         self.assertEqual(
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
-            "id│name│date│location│notes│was_modified\n"
-            + "┼┼┼┼┼\n"
-            + f"{missions[0].id}│Test0│2024-12-02│None│None│False\n"
-            + f"{missions[1].id}│Test1│2024-12-02│None│None│False\n"
-            + f"{missions[2].id}│Test2│2024-12-02│None│None│False",
+            "id│total_duration│total_size│name│date│location│notes│was_modified\n"
+            + "┼┼┼┼┼┼┼\n"
+            + f"{missions[0].id}│0│0│Test0│2024-12-02│None│None│False\n"
+            + f"{missions[1].id}│0│0│Test1│2024-12-02│None│None│False\n"
+            + f"{missions[2].id}│0│0│Test2│2024-12-02│None│None│False",
         )
 
     def test_print_tag_table(self):
@@ -69,9 +69,9 @@ class TableTests(TestCase):
         sys.stdout.flush()
         self.assertEqual(
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
-            "id│name│date│location│notes│was_modified\n"
-            + "┼┼┼┼┼\n"
-            + f"{mission[0].id}│Test│2024-12-26│None│Test│False\n"
-            + "│linebreak│││with│\n"
-            + "││││newline│",
+            "id│total_duration│total_size│name│date│location│notes│was_modified\n"
+            + "┼┼┼┼┼┼┼\n"
+            + f"{mission[0].id}│0│0│Test│2024-12-26│None│Test│False\n"
+            + "│││linebreak│││with│\n"
+            + "││││││newline│",
         )

--- a/backend/cli_commands/test_command.py
+++ b/backend/cli_commands/test_command.py
@@ -37,11 +37,11 @@ class TableTests(TestCase):
         sys.stdout.flush()
         self.assertEqual(
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
-            "id│total_duration│total_size│name│date│location│notes│was_modified\n"
-            + "┼┼┼┼┼┼┼\n"
-            + f"{missions[0].id}│0│0│Test0│2024-12-02│None│None│False\n"
-            + f"{missions[1].id}│0│0│Test1│2024-12-02│None│None│False\n"
-            + f"{missions[2].id}│0│0│Test2│2024-12-02│None│None│False",
+            "id│total_duration│total_size│robots│name│date│location│notes│was_modified\n"
+            + "┼┼┼┼┼┼┼┼\n"
+            + f"{missions[0].id}│0│0│<QuerySet[]>│Test0│2024-12-02│None│None│False\n"
+            + f"{missions[1].id}│0│0│<QuerySet[]>│Test1│2024-12-02│None│None│False\n"
+            + f"{missions[2].id}│0│0│<QuerySet[]>│Test2│2024-12-02│None│None│False",
         )
 
     def test_print_tag_table(self):
@@ -69,9 +69,9 @@ class TableTests(TestCase):
         sys.stdout.flush()
         self.assertEqual(
             self.captured_output.getvalue().strip().replace(" ", "").replace("─", ""),
-            "id│total_duration│total_size│name│date│location│notes│was_modified\n"
-            + "┼┼┼┼┼┼┼\n"
-            + f"{mission[0].id}│0│0│Test│2024-12-26│None│Test│False\n"
-            + "│││linebreak│││with│\n"
-            + "││││││newline│",
+            "id│total_duration│total_size│robots│name│date│location│notes│was_modified\n"
+            + "┼┼┼┼┼┼┼┼\n"
+            + f"{mission[0].id}│0│0│<QuerySet[]>│Test│2024-12-26│None│Test│False\n"
+            + "││││linebreak│││with│\n"
+            + "│││││││newline│",
         )

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
+from django.db.models import Sum
 from .models import Allowed_topic_names, Mission, Topic
 from .models import File
 from .models import Tag
@@ -16,19 +17,13 @@ class MissionSerializer(serializers.ModelSerializer):
 
     def get_total_duration(self, obj):
         # calculate the total duration of all files in the mission
-        files = File.objects.filter(mission=obj)
-        total_duration = 0
-        for file in files:
-            total_duration += file.duration
-        return total_duration
+        result = File.objects.filter(mission=obj).aggregate(Sum("duration"))
+        return result["duration__sum"]
 
     def get_total_size(self, obj):
         # calculate the total size of all files in the mission
-        files = File.objects.filter(mission=obj)
-        total_size = 0
-        for file in files:
-            total_size += file.size
-        return total_size
+        result = File.objects.filter(mission=obj).aggregate(Sum("size"))
+        return result["size__sum"]
 
 
 class MissionWasModifiedSerializer(serializers.ModelSerializer):

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -28,9 +28,12 @@ class MissionSerializer(serializers.ModelSerializer):
 
     def get_robots(self, obj):
         # get all robot names in the mission
-        result = (
+        result = list(
             File.objects.filter(mission=obj).values_list("robot", flat=True).distinct()
         )
+        if None in result:
+            result.remove(None)
+        result = ", ".join(result)
         return result
 
 

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -10,6 +10,7 @@ from .models import Mission_tags
 class MissionSerializer(serializers.ModelSerializer):
     total_duration = serializers.SerializerMethodField()
     total_size = serializers.SerializerMethodField()
+    robots = serializers.SerializerMethodField()
 
     class Meta:  # definition of which data to serialize
         model = Mission
@@ -24,6 +25,13 @@ class MissionSerializer(serializers.ModelSerializer):
         # calculate the total size of all files in the mission
         result = File.objects.filter(mission=obj).aggregate(Sum("size"))
         return result["size__sum"] or 0
+
+    def get_robots(self, obj):
+        # get all robot names in the mission
+        result = (
+            File.objects.filter(mission=obj).values_list("robot", flat=True).distinct()
+        )
+        return result
 
 
 class MissionWasModifiedSerializer(serializers.ModelSerializer):

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -18,12 +18,12 @@ class MissionSerializer(serializers.ModelSerializer):
     def get_total_duration(self, obj):
         # calculate the total duration of all files in the mission
         result = File.objects.filter(mission=obj).aggregate(Sum("duration"))
-        return result["duration__sum"]
+        return result["duration__sum"] or 0
 
     def get_total_size(self, obj):
         # calculate the total size of all files in the mission
         result = File.objects.filter(mission=obj).aggregate(Sum("size"))
-        return result["size__sum"]
+        return result["size__sum"] or 0
 
 
 class MissionWasModifiedSerializer(serializers.ModelSerializer):

--- a/backend/restapi/serializer.py
+++ b/backend/restapi/serializer.py
@@ -7,9 +7,28 @@ from .models import Mission_tags
 
 
 class MissionSerializer(serializers.ModelSerializer):
+    total_duration = serializers.SerializerMethodField()
+    total_size = serializers.SerializerMethodField()
+
     class Meta:  # definition of which data to serialize
         model = Mission
         fields = "__all__"
+
+    def get_total_duration(self, obj):
+        # calculate the total duration of all files in the mission
+        files = File.objects.filter(mission=obj)
+        total_duration = 0
+        for file in files:
+            total_duration += file.duration
+        return total_duration
+
+    def get_total_size(self, obj):
+        # calculate the total size of all files in the mission
+        files = File.objects.filter(mission=obj)
+        total_size = 0
+        for file in files:
+            total_size += file.size
+        return total_size
 
 
 class MissionWasModifiedSerializer(serializers.ModelSerializer):

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -71,6 +71,8 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "date": "2024-10-29",
                 "location": "TestLocation",
                 "notes": "TestOther",
+                "total_duration": 0,
+                "total_size": 0,
                 "was_modified": False,
             },
         )
@@ -82,6 +84,8 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "date": "2024-10-29",
                 "location": "TestLocation2",
                 "notes": "TestOther2",
+                "total_duration": 0,
+                "total_size": 0,
                 "was_modified": False,
             },
         )
@@ -96,6 +100,8 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
             response.data,
             {
                 "id": self.firstMission.id,
+                "total_duration": 0,
+                "total_size": 0,
                 "name": "TestMission",
                 "date": "2024-10-29",
                 "location": "TestLocation",
@@ -125,6 +131,8 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "date": "2024-10-29",
                 "location": "TestLocation",
                 "notes": "TestOther",
+                "total_duration": 0,
+                "total_size": 0,
                 "was_modified": False,
             },
         )

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -63,8 +63,14 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
+
+        # Convert the robots QuerySet to a list in the first item of response.data
+        response_data_0 = response.data[0]
+        response_data_0["robots"] = list(response_data_0["robots"])
+
+        # Compare the first mission
         self.assertEqual(
-            response.data[0],
+            response_data_0,
             {
                 "id": self.firstMission.id,
                 "name": "TestMission",
@@ -73,11 +79,18 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "notes": "TestOther",
                 "total_duration": 0,
                 "total_size": 0,
+                "robots": [],
                 "was_modified": False,
             },
         )
+
+        # Convert the robots QuerySet to a list in the second item of response.data
+        response_data_1 = response.data[1]
+        response_data_1["robots"] = list(response_data_1["robots"])
+
+        # Compare the second mission
         self.assertEqual(
-            response.data[1],
+            response_data_1,
             {
                 "id": self.secondMission.id,
                 "name": "TestMission2",
@@ -86,6 +99,7 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "notes": "TestOther2",
                 "total_duration": 0,
                 "total_size": 0,
+                "robots": [],
                 "was_modified": False,
             },
         )
@@ -96,12 +110,18 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Convert the robots QuerySet to a list
+        response_data = response.data
+        response_data["robots"] = list(response_data["robots"])
+
         self.assertEqual(
             response.data,
             {
                 "id": self.firstMission.id,
                 "total_duration": 0,
                 "total_size": 0,
+                "robots": [],
                 "name": "TestMission",
                 "date": "2024-10-29",
                 "location": "TestLocation",
@@ -123,6 +143,11 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Convert the robots QuerySet to a list
+        response_data = response.data
+        response_data["robots"] = list(response_data["robots"])
+
         self.assertEqual(
             response.data,
             {
@@ -133,6 +158,7 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "notes": "TestOther",
                 "total_duration": 0,
                 "total_size": 0,
+                "robots": [],
                 "was_modified": False,
             },
         )

--- a/backend/restapi/tests.py
+++ b/backend/restapi/tests.py
@@ -63,14 +63,8 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
-
-        # Convert the robots QuerySet to a list in the first item of response.data
-        response_data_0 = response.data[0]
-        response_data_0["robots"] = list(response_data_0["robots"])
-
-        # Compare the first mission
         self.assertEqual(
-            response_data_0,
+            response.data[0],
             {
                 "id": self.firstMission.id,
                 "name": "TestMission",
@@ -79,18 +73,12 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "notes": "TestOther",
                 "total_duration": 0,
                 "total_size": 0,
-                "robots": [],
+                "robots": "",
                 "was_modified": False,
             },
         )
-
-        # Convert the robots QuerySet to a list in the second item of response.data
-        response_data_1 = response.data[1]
-        response_data_1["robots"] = list(response_data_1["robots"])
-
-        # Compare the second mission
         self.assertEqual(
-            response_data_1,
+            response.data[1],
             {
                 "id": self.secondMission.id,
                 "name": "TestMission2",
@@ -99,7 +87,7 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "notes": "TestOther2",
                 "total_duration": 0,
                 "total_size": 0,
-                "robots": [],
+                "robots": "",
                 "was_modified": False,
             },
         )
@@ -110,18 +98,13 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # Convert the robots QuerySet to a list
-        response_data = response.data
-        response_data["robots"] = list(response_data["robots"])
-
         self.assertEqual(
             response.data,
             {
                 "id": self.firstMission.id,
                 "total_duration": 0,
                 "total_size": 0,
-                "robots": [],
+                "robots": "",
                 "name": "TestMission",
                 "date": "2024-10-29",
                 "location": "TestLocation",
@@ -143,11 +126,6 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # Convert the robots QuerySet to a list
-        response_data = response.data
-        response_data["robots"] = list(response_data["robots"])
-
         self.assertEqual(
             response.data,
             {
@@ -158,7 +136,7 @@ class RestApiPostMissionTestCase(APIAuthTestCase):
                 "notes": "TestOther",
                 "total_duration": 0,
                 "total_size": 0,
-                "robots": [],
+                "robots": "",
                 "was_modified": False,
             },
         )

--- a/docs/fetchapi/README.md
+++ b/docs/fetchapi/README.md
@@ -58,7 +58,7 @@ The `fetchapi.ts` file provides utility functions to interact with the Mission D
 - **Parameters**: `missionId` (number), `tagName` (string)
 - **Returns**: `Promise<{ mission_id: number; tag_name: string }>`
 - **Endpoint**: `POST /restapi/mission-tags/create/`
-`getFormattedDetails`, `getTotalDuration` and `getTotalSize`
+`getFormattedDetails`
 ### deleteTag(tagName)
 - Deletes a tag by its name.
 - **Parameters**: `tagName` (string)
@@ -88,20 +88,6 @@ The `fetchapi.ts` file provides utility functions to interact with the Mission D
 - Uses getDetailsByMission() to fetch the details.
 - **Parameters**: `missionID` (number)
 - **Returns**: `Promise<{ DetailViewData }> (duration and size formatted)`
-- **Endpoint**: `GET /restapi/missions/{missionID}/files/`
-
-### getTotalDuration(missionID)
-- Fetches total duration associated with a specific mission and formats it.
-- Uses getDetailsByMission() to fetch the details.
-- **Parameters**: `missionID` (number)
-- **Returns**: `Promise<{ string }> (formatted)`
-- **Endpoint**: `GET /restapi/missions/{missionID}/files/`
-
-### getTotalSize(missionID)
-- Fetches total size associated with a specific mission and formats it.
-- Uses getDetailsByMission() to fetch the details.
-- **Parameters**: `missionID` (number)
-- **Returns**: `Promise<{ string }> (formatted)`
 - **Endpoint**: `GET /restapi/missions/{missionID}/files/`
 
 ### getTopicsByFile(file_path)

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -20,6 +20,8 @@ export interface MissionData {
   location: string;
   date: string;
   notes: string;
+  total_duration: string;
+  total_size: string;
 }
 
 //This is a local representation used for mission table and details view
@@ -30,10 +32,10 @@ export interface RenderedMission {
   location: string;
   date: string;
   notes: string;
-
-  // Inherited from other data structures (details, tags, ...)
   totalDuration: string;
   totalSize: string;
+
+  // Inherited from other data structures (details, tags, ...)
   robot: string;
   tags: Tag[];
 }
@@ -68,6 +70,8 @@ export function convertToMissionData(
     location: renderedMission.location,
     date: renderedMission.date,
     notes: renderedMission.notes,
+    total_duration: renderedMission.totalDuration,
+    total_size: renderedMission.totalSize,
   };
 }
 

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -22,6 +22,7 @@ export interface MissionData {
   notes: string;
   total_duration: string;
   total_size: string;
+  robots: string[];
 }
 
 //This is a local representation used for mission table and details view
@@ -34,9 +35,9 @@ export interface RenderedMission {
   notes: string;
   totalDuration: string;
   totalSize: string;
+  robots: string[];
 
   // Inherited from other data structures (details, tags, ...)
-  robot: string;
   tags: Tag[];
 }
 
@@ -72,6 +73,7 @@ export function convertToMissionData(
     notes: renderedMission.notes,
     total_duration: renderedMission.totalDuration,
     total_size: renderedMission.totalSize,
+    robots: renderedMission.robots,
   };
 }
 

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -56,13 +56,6 @@ export const getFormattedDetails = async (
   return { files, videos, durations, sizes, robots };
 };
 
-// Get all robot names of a mission
-export const getRobotNames = async (missionId: number): Promise<string[]> => {
-  const details = await getDetailsByMission(missionId);
-
-  return details.robots;
-};
-
 /**
  * Get details about a file by path
  * @param filePath file path

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -56,32 +56,6 @@ export const getFormattedDetails = async (
   return { files, videos, durations, sizes, robots };
 };
 
-// Get total duration of all files in a mission by ID
-export const getTotalDuration = async (missionId: number): Promise<string> => {
-  const details = await getDetailsByMission(missionId);
-
-  let total = 0;
-  for (const duration in details.durations) {
-    total += parseInt(details.durations[duration], 10);
-  }
-  const stringTotal = [`${total}`];
-
-  return transformDurations(stringTotal)[0];
-};
-
-// Get total duration of all files in a mission by ID
-export const getTotalSize = async (missionId: number): Promise<string> => {
-  const details = await getDetailsByMission(missionId);
-
-  let total = 0;
-  for (const size in details.sizes) {
-    total += parseInt(details.sizes[size], 10);
-  }
-  const stringTotal = [`${total}`];
-
-  return transformSizes(stringTotal)[0];
-};
-
 // Get all robot names of a mission
 export const getRobotNames = async (missionId: number): Promise<string[]> => {
   const details = await getDetailsByMission(missionId);

--- a/frontend/app/fetchapi/tests/details.test.tsx
+++ b/frontend/app/fetchapi/tests/details.test.tsx
@@ -3,7 +3,6 @@ import { DetailViewData, FileData } from "~/data";
 import {
   getDetailsByMission,
   getFormattedDetails,
-  getRobotNames,
   getFileData,
 } from "../details";
 
@@ -100,41 +99,6 @@ describe("Fetch API Functions", () => {
       });
 
       const details = await getFormattedDetails(1);
-      expect(details).toEqual(expectedResponse);
-      expect(fetch).toHaveBeenCalledWith(
-        `${FETCH_API_BASE_URL}/missions/1/files/`,
-        {
-          method: "GET",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    });
-
-    test("getRobotNames", async () => {
-      const mockResponse = [
-        {
-          file_path: "file1.mcap",
-          robot: "hihi",
-          duration: "60000",
-          size: "1024",
-        },
-        {
-          file_path: "file2.mcap",
-          robot: "haha",
-          duration: "1200",
-          size: "2621440",
-        },
-      ];
-
-      const expectedResponse: string[] = ["hihi", "haha"];
-
-      (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce(mockResponse),
-      });
-
-      const details = await getRobotNames(1);
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,

--- a/frontend/app/fetchapi/tests/details.test.tsx
+++ b/frontend/app/fetchapi/tests/details.test.tsx
@@ -4,8 +4,6 @@ import {
   getDetailsByMission,
   getFormattedDetails,
   getRobotNames,
-  getTotalDuration,
-  getTotalSize,
   getFileData,
 } from "../details";
 
@@ -102,72 +100,6 @@ describe("Fetch API Functions", () => {
       });
 
       const details = await getFormattedDetails(1);
-      expect(details).toEqual(expectedResponse);
-      expect(fetch).toHaveBeenCalledWith(
-        `${FETCH_API_BASE_URL}/missions/1/files/`,
-        {
-          method: "GET",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    });
-
-    test("getTotalDuration should fetch total duration of all files of a mission and format them", async () => {
-      const mockResponse = [
-        {
-          file_path: "file1.mcap",
-          duration: "60000",
-          size: "1024",
-        },
-        {
-          file_path: "file2.mcap",
-          duration: "1200",
-          size: "2621440",
-        },
-      ];
-
-      const expectedResponse: string = "17:00:00";
-
-      (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce(mockResponse),
-      });
-
-      const details = await getTotalDuration(1);
-      expect(details).toEqual(expectedResponse);
-      expect(fetch).toHaveBeenCalledWith(
-        `${FETCH_API_BASE_URL}/missions/1/files/`,
-        {
-          method: "GET",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    });
-
-    test("getTotalSize should fetch total size of all files of a mission and format them", async () => {
-      const mockResponse = [
-        {
-          file_path: "file1.mcap",
-          duration: "60000",
-          size: "1024",
-        },
-        {
-          file_path: "file2.mcap",
-          duration: "1200",
-          size: "2621440",
-        },
-      ];
-
-      const expectedResponse: string = "2.50 MB";
-
-      (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce(mockResponse),
-      });
-
-      const details = await getTotalSize(1);
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,

--- a/frontend/app/fetchapi/tests/missions.test.tsx
+++ b/frontend/app/fetchapi/tests/missions.test.tsx
@@ -36,7 +36,8 @@ describe("Fetch API Functions", () => {
           date: "2023-01-01",
           notes: "Test remarks",
           total_duration: "60000",
-          total_size: "1024"
+          total_size: "1024",
+          robots: [],
         },
       ];
 
@@ -61,7 +62,8 @@ describe("Fetch API Functions", () => {
         date: "2023-02-01",
         notes: "New remarks",
         total_duration: "60000",
-        total_size: "1024"
+        total_size: "1024",
+        robots: []
       };
 
       const mockResponse: MissionData = {
@@ -71,7 +73,8 @@ describe("Fetch API Functions", () => {
         date: "2023-02-01",
         notes: "New remarks",
         total_duration: "60000",
-        total_size: "1024"
+        total_size: "1024",
+        robots: []
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({
@@ -100,7 +103,8 @@ describe("Fetch API Functions", () => {
         date: "2023-03-01",
         notes: "Single remarks",
         total_duration: "60000",
-        total_size: "1024"
+        total_size: "1024",
+        robots: []
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({
@@ -125,7 +129,8 @@ describe("Fetch API Functions", () => {
         date: "2023-04-01",
         notes: "Updated remarks",
         total_duration: "60000",
-        total_size: "1024"
+        total_size: "1024",
+        robots: []
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({

--- a/frontend/app/fetchapi/tests/missions.test.tsx
+++ b/frontend/app/fetchapi/tests/missions.test.tsx
@@ -35,6 +35,8 @@ describe("Fetch API Functions", () => {
           location: "Test Location",
           date: "2023-01-01",
           notes: "Test remarks",
+          total_duration: "60000",
+          total_size: "1024"
         },
       ];
 
@@ -58,6 +60,8 @@ describe("Fetch API Functions", () => {
         location: "New Location",
         date: "2023-02-01",
         notes: "New remarks",
+        total_duration: "60000",
+        total_size: "1024"
       };
 
       const mockResponse: MissionData = {
@@ -66,6 +70,8 @@ describe("Fetch API Functions", () => {
         location: "New Location",
         date: "2023-02-01",
         notes: "New remarks",
+        total_duration: "60000",
+        total_size: "1024"
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({
@@ -93,6 +99,8 @@ describe("Fetch API Functions", () => {
         location: "Single Location",
         date: "2023-03-01",
         notes: "Single remarks",
+        total_duration: "60000",
+        total_size: "1024"
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({
@@ -116,6 +124,8 @@ describe("Fetch API Functions", () => {
         location: "Updated Location",
         date: "2023-04-01",
         notes: "Updated remarks",
+        total_duration: "60000",
+        total_size: "1024"
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -42,10 +42,8 @@ import {
 } from "~/fetchapi/tags";
 import {
   getRobotNames,
-  getTotalDuration,
-  getTotalSize,
 } from "~/fetchapi/details";
-import { formatRobotNames } from "~/utilities/FormatHandler";
+import { formatRobotNames, transformDurations, transformSizes } from "~/utilities/FormatHandler";
 import { CookieSerializeOptions } from "@remix-run/node";
 
 interface ThProps {
@@ -192,25 +190,20 @@ export function Overview() {
           // Fetch tags for each mission
           const tags: Tag[] = await getTagsByMission(missions[i].id);
           tags.sort((a, b) => a.name.localeCompare(b.name));
-          // Fetch total duration for each mission
-          const totalDuration: string = await getTotalDuration(missions[i].id);
-          // Fetch total size for each mission
-          const totalSize: string = await getTotalSize(missions[i].id);
 
           // Fetch robot name for each mission
           const robots_formatted: string = formatRobotNames(
             await getRobotNames(missions[i].id),
             false
           );
-
           renderedMissions.push({
             id: missions[i].id,
             name: missions[i].name,
             location: missions[i].location,
             date: missions[i].date,
             notes: missions[i].notes,
-            totalDuration: totalDuration,
-            totalSize: totalSize,
+            totalDuration: transformDurations([missions[i].total_duration])[0],
+            totalSize: transformSizes([missions[i].total_size])[0],
             robot: robots_formatted || "",
             tags: tags || [],
           });

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -40,9 +40,6 @@ import {
   getTagsByMission,
   removeTagFromMission,
 } from "~/fetchapi/tags";
-import {
-  getRobotNames,
-} from "~/fetchapi/details";
 import { formatRobotNames, transformDurations, transformSizes } from "~/utilities/FormatHandler";
 import { CookieSerializeOptions } from "@remix-run/node";
 
@@ -90,7 +87,7 @@ function filterData(
     const matchesSearch = keys(data[0]).some((key) => {
       const value = item[key];
       if (Array.isArray(value)) {
-        return value.some((tag) => tag.name.toLowerCase().includes(query));
+        return value.some((tag) => typeof tag !== "string" && tag.name.toLowerCase().includes(query));
       }
       return typeof value === "string" && value.toLowerCase().includes(query);
     });
@@ -191,11 +188,6 @@ export function Overview() {
           const tags: Tag[] = await getTagsByMission(missions[i].id);
           tags.sort((a, b) => a.name.localeCompare(b.name));
 
-          // Fetch robot name for each mission
-          const robots_formatted: string = formatRobotNames(
-            await getRobotNames(missions[i].id),
-            false
-          );
           renderedMissions.push({
             id: missions[i].id,
             name: missions[i].name,
@@ -204,7 +196,7 @@ export function Overview() {
             notes: missions[i].notes,
             totalDuration: transformDurations([missions[i].total_duration])[0],
             totalSize: transformSizes([missions[i].total_size])[0],
-            robot: robots_formatted || "",
+            robots: missions[i].robots,
             tags: tags || [],
           });
         }
@@ -295,7 +287,7 @@ export function Overview() {
       </Table.Td>
       <Table.Td>{row.totalDuration}</Table.Td>
       <Table.Td>{row.totalSize}</Table.Td>
-      <Table.Td>{row.robot}</Table.Td>
+      <Table.Td>{formatRobotNames(row.robots, false)}</Table.Td>
       <Table.Td>{row.date}</Table.Td>
       <Table.Td>
         <div style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>
@@ -478,7 +470,7 @@ export function Overview() {
     { key: "location", label: "Location" },
     { key: "totalDuration", label: "Duration" },
     { key: "totalSize", label: "Size" },
-    { key: "robot", label: "Robot" },
+    { key: "robots", label: "Robot" },
     { key: "date", label: "Date" },
     { key: "notes", label: "Notes" },
     { key: "tags", label: "Tags" },

--- a/frontend/app/pages/missions/Overview.tsx
+++ b/frontend/app/pages/missions/Overview.tsx
@@ -40,7 +40,7 @@ import {
   getTagsByMission,
   removeTagFromMission,
 } from "~/fetchapi/tags";
-import { formatRobotNames, transformDurations, transformSizes } from "~/utilities/FormatHandler";
+import { transformDurations, transformSizes } from "~/utilities/FormatHandler";
 import { CookieSerializeOptions } from "@remix-run/node";
 
 interface ThProps {
@@ -287,7 +287,7 @@ export function Overview() {
       </Table.Td>
       <Table.Td>{row.totalDuration}</Table.Td>
       <Table.Td>{row.totalSize}</Table.Td>
-      <Table.Td>{formatRobotNames(row.robots, false)}</Table.Td>
+      <Table.Td>{row.robots}</Table.Td>
       <Table.Td>{row.date}</Table.Td>
       <Table.Td>
         <div style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -9,14 +9,12 @@ import { useEffect, useState } from "react";
 import { DetailViewData, MissionData, RenderedMission, Tag } from "~/data";
 import {
   getFormattedDetails,
-  getTotalDuration,
-  getTotalSize,
 } from "~/fetchapi/details";
 import { getMission } from "~/fetchapi/missions";
 import { getTagsByMission, getTags } from "~/fetchapi/tags";
 import { CreateAppShell } from "~/layout/AppShell";
 import DetailsView from "~/pages/details/DetailsView";
-import { transformFilePaths } from "~/utilities/FormatHandler";
+import { transformDurations, transformFilePaths, transformSizes } from "~/utilities/FormatHandler";
 import { sessionStorage } from "~/utilities/LoginHandler";
 
 export const meta: MetaFunction = () => {
@@ -98,10 +96,10 @@ function Detail() {
         setDetailViewData(detailViewData);
 
         // data for the information view (size)
-        setTotalSize(await getTotalSize(mission.id));
+        setTotalSize(transformSizes([mission.total_size])[0]);
 
         // data for the information view (duration)
-        setTotalDuration(await getTotalDuration(mission.id));
+        setTotalDuration(transformDurations([mission.total_duration])[0]);
       } catch (e: any) {
         if (e instanceof Error) {
           setError(e.message);


### PR DESCRIPTION
resolves #236 

# Changes
I removed the functions `getTotalDuration` , `getTotalSize`  and `getRobotNames` from the frontend.
I modified the MissionSerializer, so now the totalDuration, totalSize and the robot names of a Mission get calculated in the Backend by the MissionSerializer.