### PR TITLE
Added type tags and filter option to the detail view.

### DIFF
--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -1,9 +1,10 @@
-import { Table, ThemeIcon, UnstyledButton } from "@mantine/core";
+import { Badge, Table, ThemeIcon, UnstyledButton } from "@mantine/core";
 import { DetailViewData } from "~/data";
 import { useNavigate } from "@remix-run/react";
 import { IconClipboard } from "@tabler/icons-react";
 import { useClipboard } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
+import { useState } from "react";
 
 export function ShowDatasets({
   data,
@@ -16,55 +17,105 @@ export function ShowDatasets({
   const clipboard = useClipboard({ timeout: 500 });
   const missionPathSplitted: string[] = basePath.split("/").slice(-2, -1);
 
+  const [searchFor, setSearchFor] = useState<string>("");
+
   // Creates rows of table
-  const rows = data.files.map((file, index) => (
-    <Table.Tr
-      key={file}
-      onClick={() =>
-        navigate(
-          "/dataset?fileName=" + missionPathSplitted.concat(file).join("/"),
-        )
-      }
-      // Change color on mouse hover
-      style={{
-        cursor: "pointer",
-        transition: "background-color 0.2s ease",
-      }}
-      onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#f1f3f5")}
-      onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "")}
-    >
-      {/* Inserts data from DetailViewData, see data.tsx */}
-      <Table.Td>
-        <UnstyledButton
-          onClick={(e) => {
-            e.stopPropagation();
-            clipboard.copy(basePath + file);
+  const rows = data.files.map((file, index) => {
+    let type = "?";
+    if (file.startsWith("train/") || file.startsWith("train\\")) type = "train";
+    else if (file.startsWith("test/") || file.startsWith("test\\"))
+      type = "test";
 
-            notifications.clean();
+    if (searchFor !== "" && searchFor !== type) return;
 
-            notifications.show({
-              title: "Copied to clipboard!",
-              message: basePath + file,
-              color: "orange",
-              radius: "md",
-            });
-          }}
-        >
-          <ThemeIcon variant="white">
-            <IconClipboard
-              stroke={2}
-              color="orange"
-              style={{ width: "50%", height: "50%" }}
-            />
-          </ThemeIcon>
-        </UnstyledButton>
-        {file}
-      </Table.Td>
-      <Table.Td>{data.durations[index]}</Table.Td>
-      <Table.Td>{data.sizes[index]}</Table.Td>
-      <Table.Td>{data.robots[index]}</Table.Td>
-    </Table.Tr>
-  ));
+    return (
+      <Table.Tr
+        key={file}
+        onClick={() =>
+          navigate(
+            "/dataset?fileName=" + missionPathSplitted.concat(file).join("/")
+          )
+        }
+        // Change color on mouse hover
+        style={{
+          cursor: "pointer",
+          transition: "background-color 0.2s ease",
+        }}
+        onMouseEnter={(e) =>
+          (e.currentTarget.style.backgroundColor = "#f1f3f5")
+        }
+        onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "")}
+      >
+        {/* Inserts data from DetailViewData, see data.tsx */}
+        <Table.Td>
+          <UnstyledButton
+            onClick={(e) => {
+              e.stopPropagation();
+              clipboard.copy(basePath + file);
+
+              notifications.clean();
+
+              notifications.show({
+                title: "Copied to clipboard!",
+                message: basePath + file,
+                color: "orange",
+                radius: "md",
+              });
+            }}
+          >
+            <ThemeIcon variant="white">
+              <IconClipboard
+                stroke={2}
+                color="orange"
+                style={{ width: "50%", height: "50%" }}
+              />
+            </ThemeIcon>
+          </UnstyledButton>
+          {(() => {
+            let displayFile = file;
+            if (file.startsWith("train/") || file.startsWith("train\\"))
+              displayFile = file.replace("train/", "").replace("train\\", "");
+            else if (file.startsWith("test/") || file.startsWith("test\\"))
+              displayFile = file.replace("test/", "").replace("test\\", "");
+
+            return displayFile;
+          })()}
+        </Table.Td>
+        <Table.Td>{data.durations[index]}</Table.Td>
+        <Table.Td>{data.sizes[index]}</Table.Td>
+        <Table.Td>
+          {(() => {
+            let color = "gray";
+
+            if (type === "train") color = "green";
+            else if (type === "test") color = "red";
+
+            return (
+              <Badge
+                onClick={(e) => {
+                  e.stopPropagation();
+
+                  if (searchFor === type) setSearchFor("");
+                  else setSearchFor(type);
+                }}
+                key={type}
+                color={color}
+                variant="light"
+                style={{
+                  textTransform: "none",
+                  cursor: "pointer",
+                  border: searchFor == type ? "2px solid" : "none",
+                }}
+              >
+                {type}
+              </Badge>
+            );
+          })()}
+        </Table.Td>
+        <Table.Td>{data.robots[index]}</Table.Td>
+      </Table.Tr>
+    );
+  });
 
   // Returns the filled table with DatasetView
   return (
@@ -75,6 +126,7 @@ export function ShowDatasets({
             <Table.Th>File</Table.Th>
             <Table.Th>Duration</Table.Th>
             <Table.Th>Size</Table.Th>
+            <Table.Th>Type</Table.Th>
             <Table.Th>Robot</Table.Th>
           </Table.Tr>
         </Table.Thead>

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -78,6 +78,9 @@ export function ShowDatasets({
             else if (file.startsWith("test/") || file.startsWith("test\\"))
               displayFile = file.replace("test/", "").replace("test\\", "");
 
+            //Remove the redundant folder extension with the same name:
+            displayFile = displayFile.replace(/^[^\\\/]+[\\\/]/, '')
+
             return displayFile;
           })()}
         </Table.Td>


### PR DESCRIPTION
Hi, this PR solves issue #245 by adding a new column to visualize the dataset type (train or test). The type is identified by the prefix train/ and test/ from the file path. If the prefix is unknown, the type is replaced by ?.

The prefix train/ and test/ is now omitted in the file name, to prevent visual redundancy. 

![image](https://github.com/user-attachments/assets/f6d0ed71-a03c-42e5-8875-b12fa58e3dbe)

To filter for a type, click on a type tag, as previously implemented in the Mission table.
