### PR TITLE
Add feedback when pressing login button

### DIFF
--- a/frontend/app/pages/login/LoginPage.module.css
+++ b/frontend/app/pages/login/LoginPage.module.css
@@ -4,3 +4,7 @@
       var(--mantine-font-family);
     font-weight: 700;
   }
+
+.login_button:hover {
+    opacity: 0.8;
+  }

--- a/frontend/app/pages/login/LoginPage.tsx
+++ b/frontend/app/pages/login/LoginPage.tsx
@@ -14,7 +14,7 @@ export function LoginView({ error }: { error?: string }) {
 
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
     const button = e.currentTarget;
-    button.innerHTML = 'Signing in&nbsp;.&nbsp;.&nbsp;.'; // Set the button text to "Signing in . . ." to indicate loading
+    button.innerHTML = 'Logging in&nbsp;.&nbsp;.&nbsp;.'; // Set the button text to "Logging in . . ." to indicate loading
 
     const delay = 300; // Change the dots every 300ms
     const numberOfDots = 3; // Number of dots to be shown
@@ -24,12 +24,14 @@ export function LoginView({ error }: { error?: string }) {
     const interval = setInterval(() => {
       dots = (dots + 1) % (numberOfDots + 1);
       spaces = numberOfDots - dots;
-      button.innerHTML = `Signing in${'&nbsp;.'.repeat(dots)}${'&nbsp;&nbsp;'.repeat(spaces)}`; // Animate the dots
+      button.innerHTML = `Logging in${'&nbsp;.'.repeat(dots)}${'&nbsp;&nbsp;'.repeat(spaces)}`; // Animate the dots
 
       const alert = document.querySelector('.mantine-Alert-root');
-      if (!button.closest('form')?.checkValidity() || alert !== null) { // End if the form is invalid or an alert is shown
+      const isValid = button.closest('form')?.checkValidity();
+      
+      if (!isValid || alert !== null) { // End if the form is invalid or an alert is shown
         clearInterval(interval); // Stop the animation
-        button.innerText = 'Sign in'; // Reset the button text
+        button.innerText = 'Log in'; // Reset the button text
       }
 
     }, delay);
@@ -97,7 +99,7 @@ export function LoginView({ error }: { error?: string }) {
               className={classes.login_button}
               onClick={handleSubmit}
             >
-              Sign in
+              Log in
             </Button>
           </Paper>
         </div>

--- a/frontend/app/pages/login/LoginPage.tsx
+++ b/frontend/app/pages/login/LoginPage.tsx
@@ -26,10 +26,10 @@ export function LoginView({ error }: { error?: string }) {
       spaces = numberOfDots - dots;
       button.innerHTML = `Logging in${'&nbsp;.'.repeat(dots)}${'&nbsp;&nbsp;'.repeat(spaces)}`; // Animate the dots
 
-      const alert = document.querySelector('.mantine-Alert-root');
       const isValid = button.closest('form')?.checkValidity();
+      const alert = document.querySelector('.mantine-Alert-root');
       
-      if (!isValid || alert !== null) { // End if the form is invalid or an alert is shown
+      if (!isValid || (alert !== null) || error) { // End if the form is invalid or an alert or error is shown
         clearInterval(interval); // Stop the animation
         button.innerText = 'Log in'; // Reset the button text
       }

--- a/frontend/app/pages/login/LoginPage.tsx
+++ b/frontend/app/pages/login/LoginPage.tsx
@@ -11,6 +11,30 @@ import { Form } from "@remix-run/react";
 import { IconInfoCircle } from "@tabler/icons-react";
 
 export function LoginView({ error }: { error?: string }) {
+
+  const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const button = e.currentTarget;
+    button.innerHTML = 'Signing in&nbsp;.&nbsp;.&nbsp;.'; // Set the button text to "Signing in . . ." to indicate loading
+
+    const delay = 300; // Change the dots every 300ms
+    const numberOfDots = 3; // Number of dots to be shown
+    let dots = 0;
+    let spaces = numberOfDots;
+
+    const interval = setInterval(() => {
+      dots = (dots + 1) % (numberOfDots + 1);
+      spaces = numberOfDots - dots;
+      button.innerHTML = `Signing in${'&nbsp;.'.repeat(dots)}${'&nbsp;&nbsp;'.repeat(spaces)}`; // Animate the dots
+
+      const alert = document.querySelector('.mantine-Alert-root');
+      if (!button.closest('form')?.checkValidity() || alert !== null) { // End if the form is invalid or an alert is shown
+        clearInterval(interval); // Stop the animation
+        button.innerText = 'Sign in'; // Reset the button text
+      }
+
+    }, delay);
+  };
+
   return (
     <Form method="post">
       <div
@@ -70,6 +94,8 @@ export function LoginView({ error }: { error?: string }) {
               mt="xl"
               variant="gradient"
               gradient={{ from: "yellow", to: "orange", deg: 269 }}
+              className={classes.login_button}
+              onClick={handleSubmit}
             >
               Sign in
             </Button>

--- a/frontend/app/pages/login/LoginPage.tsx
+++ b/frontend/app/pages/login/LoginPage.tsx
@@ -13,7 +13,12 @@ import { IconInfoCircle } from "@tabler/icons-react";
 export function LoginView({ error }: { error?: string }) {
 
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const button = e.currentTarget;
+    e.preventDefault(); // Prevent the form from submitting immediately
+    document.querySelector('.mantine-Alert-root')?.remove(); // Remove any existing alerts
+    const button = e.currentTarget; // Get the button that was clicked
+    const form = button.closest('form');
+    form?.submit(); // Submit the form
+
     button.innerHTML = 'Logging in&nbsp;.&nbsp;.&nbsp;.'; // Set the button text to "Logging in . . ." to indicate loading
 
     const delay = 300; // Change the dots every 300ms
@@ -26,10 +31,10 @@ export function LoginView({ error }: { error?: string }) {
       spaces = numberOfDots - dots;
       button.innerHTML = `Logging in${'&nbsp;.'.repeat(dots)}${'&nbsp;&nbsp;'.repeat(spaces)}`; // Animate the dots
 
-      const isValid = button.closest('form')?.checkValidity();
+      const isValid = form?.checkValidity();
       const alert = document.querySelector('.mantine-Alert-root');
       
-      if (!isValid || (alert !== null) || error) { // End if the form is invalid or an alert or error is shown
+      if (!isValid || (alert !== null)) { // End if the form is invalid or an alert is shown
         clearInterval(interval); // Stop the animation
         button.innerText = 'Log in'; // Reset the button text
       }

--- a/frontend/app/pages/login/LoginPage.tsx
+++ b/frontend/app/pages/login/LoginPage.tsx
@@ -13,10 +13,11 @@ import { IconInfoCircle } from "@tabler/icons-react";
 export function LoginView({ error }: { error?: string }) {
 
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault(); // Prevent the form from submitting immediately
-    document.querySelector('.mantine-Alert-root')?.remove(); // Remove any existing alerts
     const button = e.currentTarget; // Get the button that was clicked
     const form = button.closest('form');
+    
+    e.preventDefault(); // Prevent the form from submitting immediately
+    document.querySelector('.mantine-Alert-root')?.remove(); // Remove any existing alerts
     form?.submit(); // Submit the form
 
     button.innerHTML = 'Logging in&nbsp;.&nbsp;.&nbsp;.'; // Set the button text to "Logging in . . ." to indicate loading


### PR DESCRIPTION
This PR resolves issue #238 
#
### Changes
#### Renamed the button from "Sign in" to "Log in"
#### Added a small animation when pressing the login button
- Now when pressing the login button, the text changes from "Log in" to "Logging in . . ." and the dots are animated to show that the page has not hung up or similar.
- The text on the button changes back to "Log in" if the login was not successfull ( `invalid` or `alert`  ).
- The `alert` will be regenerated on submit to prevent the animation from stopping unintentionally

#### Also added feedback when hovering over the login button
- Now when hovering over the login button, it blurs a bit to show feedback.