### PR TITLE
Added dynamic type handling in the detail view

### DIFF
--- a/docs/fetchapi/README.md
+++ b/docs/fetchapi/README.md
@@ -3,8 +3,6 @@
 ## Overview
 The `fetchapi.ts` file provides utility functions to interact with the Mission Database REST API. The functions handle API requests and responses, providing a simple interface for fetching, creating, updating, and deleting mission data.
 
-**NOTE**: The functions return `BackendMissionData` as the REST API currently does not support all fields from `MissionData`. The function `fetchAndTransformMissions()` will fill in missing fields using data from `RandomData`, which is used when `USE_RANDOM_DATA=true`.
-
 ## Functions
 
 ### setWasModified(id, was_modified)
@@ -39,15 +37,6 @@ The `fetchapi.ts` file provides utility functions to interact with the Mission D
 - **Returns**: `Promise<void>`
 - **Endpoint**: `DELETE /restapi/missions/{id}`
 
-### fetchAndTransformMission(id)
-- Fetches a mission using `getMission(id)` and transforms it into `MissionData`. If `USE_RANDOM_DATA=true`, it returns random data.
-- **Parameters**: `id` (number)
-- **Returns**: `Promise<MissionData>`
-
-### fetchAndTransformMissions()
-- Fetches all missions using `getMissions()` and transforms them into `MissionData`. Fills missing fields with random data if `USE_RANDOM_DATA=true`.
-- **Returns**: `Promise<MissionData[]>`
-
 ### getTags()
 - Fetches all tags from the backend.
 - **Returns**: `Promise<Tag[]>`
@@ -77,18 +66,17 @@ The `fetchapi.ts` file provides utility functions to interact with the Mission D
 - **Returns**: `Promise<{ id: number; name: string; location: string }[]>`
 - **Endpoint**: `GET /restapi/tags/missions/{tagName}`
 
-### getDetailsByMission(missionID)
-- Fetches all details associated with a specific mission.
+### getFilesByMission(missionID)
+- Fetches all file data associated with a specific mission.
 - **Parameters**: `missionID` (number)
-- **Returns**: `Promise<{ DetailViewData }>`
+- **Returns**: `Promise<{ FileData[] }>`
 - **Endpoint**: `GET /restapi/missions/{missionID}/files/`
 
-### getForamttedDetails(missionID)
-- Fetches all details associated with a specific mission and formats duration and size.
-- Uses getDetailsByMission() to fetch the details.
-- **Parameters**: `missionID` (number)
-- **Returns**: `Promise<{ DetailViewData }> (duration and size formatted)`
-- **Endpoint**: `GET /restapi/missions/{missionID}/files/`
+### getFileData(filePath)
+- Fetch all file information related to a file path
+- **Parameters**: `filePath` (filePath)
+- **Returns**: `Promise<{ FileData }>`
+- **Endpoint**: `GET /restapi//file/{filePath}`
 
 ### getTopicsByFile(file_path)
 - Fetches all topics associated with a specific file.
@@ -116,9 +104,7 @@ The `fetchapi.ts` file provides utility functions to interact with the Mission D
 -------------------------
 ## Configuration
 - **`FETCH_API_BASE_URL`**: The base URL for API requests, defined in `config.tsx`. Set to: `http://127.0.0.1:8000/restapi`
-- **`USE_RANDOM_DATA`**: Flag in `config.tsx` to switch between using backend data or random data from `frontend/app/RandomData.tsx` for mission fields.
 
 ## Notes
 - All functions use `credentials: 'include'`.
 - Error handling is implemented for each function individually, with specific error messages for different statuses (e.g., `400`, `404`).
-- `fetchAndTransformMissions()` and `fetchAndTransformMission()` will either use real backend data or fallback to random data depending on the `USE_RANDOM_DATA` flag. If random data is used, it comes from the `RandomData.tsx` file in the frontend.

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -4,9 +4,9 @@ export interface Tag {
 }
 
 //Fetch this data by mission_id from MissionTableData
+//This is essentially the FileData, but a seperate type is used to make the handling more easier.
 export interface DetailViewData {
   files: string[];
-  videos: string[];
   durations: string[];
   sizes: string[];
   robots: string[];
@@ -76,6 +76,24 @@ export function convertToMissionData(
     total_size: renderedMission.totalSize,
     robots: renderedMission.robots,
   };
+}
+
+export function convertToDetailViewData(fileData: FileData[]) : DetailViewData {
+  const files: string[] = [];
+  const durations: string[] = [];
+  const sizes: string[] = [];
+  const robots: string[] = [];
+  const types: string[] = [];
+
+  for (const d in fileData) {
+    files.push(fileData[d].filePath);
+    durations.push(fileData[d].duration);
+    sizes.push(fileData[d].size);
+    robots.push(fileData[d].robot);
+    types.push(fileData[d].type);
+  }
+
+  return { files, durations, sizes, robots, types };
 }
 
 export interface FileData {

--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -10,6 +10,7 @@ export interface DetailViewData {
   durations: string[];
   sizes: string[];
   robots: string[];
+  types: string[];
 }
 
 //Represents a mission in the backend

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -3,7 +3,7 @@ import { FETCH_API_BASE_URL } from "~/config";
 import { getHeaders } from "./headers";
 import { transformDurations, transformSizes } from "~/utilities/FormatHandler";
 
-export const getDetailsByMission = async (
+export const GetFilesByMission = async (
   missionId: number,
 ): Promise<DetailViewData> => {
   const response = await fetch(
@@ -28,6 +28,7 @@ export const getDetailsByMission = async (
   const durations: string[] = [];
   const sizes: string[] = [];
   const robots: string[] = [];
+  const types: string[] = [];
 
   for (const d in data) {
     files.push(data[d].file_path);
@@ -35,16 +36,17 @@ export const getDetailsByMission = async (
     durations.push(data[d].duration);
     sizes.push(data[d].size);
     robots.push(data[d].robot);
+    types.push(data[d].type);
   }
 
-  return { files, videos, durations, sizes, robots };
+  return { files, videos, durations, sizes, robots, types };
 };
 
 // Get details by mission in correct format
-export const getFormattedDetails = async (
+export const getFormattedFiles = async (
   missionId: number,
 ): Promise<DetailViewData> => {
-  const details = await getDetailsByMission(missionId);
+  const details = await GetFilesByMission(missionId);
 
   const files = details.files;
   const videos = details.videos;
@@ -52,8 +54,9 @@ export const getFormattedDetails = async (
   const durations = transformDurations(details.durations);
   const sizes = transformSizes(details.sizes);
   const robots = details.robots;
+  const types = details.types;
 
-  return { files, videos, durations, sizes, robots };
+  return { files, videos, durations, sizes, robots, types };
 };
 
 /**

--- a/frontend/app/fetchapi/details.tsx
+++ b/frontend/app/fetchapi/details.tsx
@@ -5,7 +5,7 @@ import { transformDurations, transformSizes } from "~/utilities/FormatHandler";
 
 export const GetFilesByMission = async (
   missionId: number,
-): Promise<DetailViewData> => {
+): Promise<FileData[]> => {
   const response = await fetch(
     `${FETCH_API_BASE_URL}/missions/${missionId}/files/`,
     {
@@ -23,40 +23,23 @@ export const GetFilesByMission = async (
 
   const data = await response.json();
 
-  const files: string[] = [];
-  const videos: string[] = [];
-  const durations: string[] = [];
-  const sizes: string[] = [];
-  const robots: string[] = [];
-  const types: string[] = [];
+  const files: FileData[] = [];
 
   for (const d in data) {
-    files.push(data[d].file_path);
-    videos.push(data[d].video_path);
-    durations.push(data[d].duration);
-    sizes.push(data[d].size);
-    robots.push(data[d].robot);
-    types.push(data[d].type);
+    files.push({
+      filePath: data[d].file_path,
+      fileUrl: new URL(data[d].file_url),
+      videoPath: data[d].video_path,
+      videoUrl: data[d].video_url ? new URL(data[d].video_url) : null,
+      duration: transformDurations([data[d].duration])[0],
+      size: transformSizes([data[d].size])[0],
+      robot: data[d].robot,
+      type: data[d].type,
+    });
+
   }
 
-  return { files, videos, durations, sizes, robots, types };
-};
-
-// Get details by mission in correct format
-export const getFormattedFiles = async (
-  missionId: number,
-): Promise<DetailViewData> => {
-  const details = await GetFilesByMission(missionId);
-
-  const files = details.files;
-  const videos = details.videos;
-  // transform durations and sizes to correct form
-  const durations = transformDurations(details.durations);
-  const sizes = transformSizes(details.sizes);
-  const robots = details.robots;
-  const types = details.types;
-
-  return { files, videos, durations, sizes, robots, types };
+  return files;
 };
 
 /**

--- a/frontend/app/fetchapi/tests/details.test.tsx
+++ b/frontend/app/fetchapi/tests/details.test.tsx
@@ -2,7 +2,6 @@ import { FETCH_API_BASE_URL } from "~/config";
 import { DetailViewData, FileData } from "~/data";
 import {
   GetFilesByMission,
-  getFormattedFiles,
   getFileData,
 } from "../details";
 
@@ -27,16 +26,20 @@ describe("Fetch API Functions", () => {
     test("getDetailsByMission should fetch details of a mission", async () => {
       const mockResponse = [
         {
-          file_path: "file1.mcap",
+          file_url: "http://example.com/file/download/file1.mcap",
           video_path: "file1.mp4",
-          duration: "60000",
+          video_url: "http://example.com/file/stream/file1.mcap",
+          file_path: "file1.mcap",
+          duration: "3600",
           size: "1024",
           robot: "hihi",
           type: "train",
         },
         {
-          file_path: "file2.mcap",
+          file_url: "http://example.com/file/download/file2.mcap",
           video_path: "file2.mp4",
+          video_url: "http://example.com/file/stream/file2.mcap",
+          file_path: "file2.mcap",
           duration: "1200",
           size: "2621440",
           robot: "haha",
@@ -44,14 +47,28 @@ describe("Fetch API Functions", () => {
         },
       ];
 
-      const expectedResponse: DetailViewData = {
-        files: ["file1.mcap", "file2.mcap"],
-        videos: ["file1.mp4", "file2.mp4"],
-        durations: ["60000", "1200"],
-        sizes: ["1024", "2621440"],
-        robots: ["hihi", "haha"],
-        types: ["train", "test"],
-      };
+      const expectedResponse: FileData[] = [
+        {
+          filePath: "file1.mcap",
+          fileUrl: new URL("http://example.com/file/download/file1.mcap"),
+          videoPath: "file1.mp4",
+          videoUrl: new URL("http://example.com/file/stream/file1.mcap"),
+          duration: "01:00:00",
+          size: "1.00 KB",
+          robot: "hihi",
+          type: "train",
+        },
+        {
+          filePath: "file2.mcap",
+          fileUrl: new URL("http://example.com/file/download/file2.mcap"),
+          videoPath: "file2.mp4",
+          videoUrl: new URL("http://example.com/file/stream/file2.mcap"),
+          duration: "00:20:00",
+          size: "2.50 MB",
+          robot: "haha",
+          type: "test",
+        },
+      ];
 
       (fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
@@ -59,52 +76,6 @@ describe("Fetch API Functions", () => {
       });
 
       const details = await GetFilesByMission(1);
-      expect(details).toEqual(expectedResponse);
-      expect(fetch).toHaveBeenCalledWith(
-        `${FETCH_API_BASE_URL}/missions/1/files/`,
-        {
-          method: "GET",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    });
-
-    test("getFormattedDetails should fetch details of a mission and format them", async () => {
-      const mockResponse = [
-        {
-          file_path: "file1.mcap",
-          video_path: "file1.mp4",
-          duration: "60000",
-          size: "1024",
-          robot: "hihi",
-          type: "hello",
-        },
-        {
-          file_path: "file2.mcap",
-          video_path: "file2.mp4",
-          duration: "1200",
-          size: "2621440",
-          robot: "haha",
-          type: "world",
-        },
-      ];
-
-      const expectedResponse: DetailViewData = {
-        files: ["file1.mcap", "file2.mcap"],
-        videos: ["file1.mp4", "file2.mp4"],
-        durations: ["16:40:00", "00:20:00"],
-        sizes: ["1.00 KB", "2.50 MB"],
-        robots: ["hihi", "haha"],
-        types: ["hello", "world"],
-      };
-
-      (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce(mockResponse),
-      });
-
-      const details = await getFormattedFiles(1);
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,

--- a/frontend/app/fetchapi/tests/details.test.tsx
+++ b/frontend/app/fetchapi/tests/details.test.tsx
@@ -1,8 +1,8 @@
 import { FETCH_API_BASE_URL } from "~/config";
 import { DetailViewData, FileData } from "~/data";
 import {
-  getDetailsByMission,
-  getFormattedDetails,
+  GetFilesByMission,
+  getFormattedFiles,
   getFileData,
 } from "../details";
 
@@ -32,6 +32,7 @@ describe("Fetch API Functions", () => {
           duration: "60000",
           size: "1024",
           robot: "hihi",
+          type: "train",
         },
         {
           file_path: "file2.mcap",
@@ -39,6 +40,7 @@ describe("Fetch API Functions", () => {
           duration: "1200",
           size: "2621440",
           robot: "haha",
+          type: "test",
         },
       ];
 
@@ -48,6 +50,7 @@ describe("Fetch API Functions", () => {
         durations: ["60000", "1200"],
         sizes: ["1024", "2621440"],
         robots: ["hihi", "haha"],
+        types: ["train", "test"],
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({
@@ -55,7 +58,7 @@ describe("Fetch API Functions", () => {
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
-      const details = await getDetailsByMission(1);
+      const details = await GetFilesByMission(1);
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,
@@ -75,6 +78,7 @@ describe("Fetch API Functions", () => {
           duration: "60000",
           size: "1024",
           robot: "hihi",
+          type: "hello",
         },
         {
           file_path: "file2.mcap",
@@ -82,6 +86,7 @@ describe("Fetch API Functions", () => {
           duration: "1200",
           size: "2621440",
           robot: "haha",
+          type: "world",
         },
       ];
 
@@ -91,6 +96,7 @@ describe("Fetch API Functions", () => {
         durations: ["16:40:00", "00:20:00"],
         sizes: ["1.00 KB", "2.50 MB"],
         robots: ["hihi", "haha"],
+        types: ["hello", "world"],
       };
 
       (fetch as jest.Mock).mockResolvedValueOnce({
@@ -98,7 +104,7 @@ describe("Fetch API Functions", () => {
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
-      const details = await getFormattedDetails(1);
+      const details = await getFormattedFiles(1);
       expect(details).toEqual(expectedResponse);
       expect(fetch).toHaveBeenCalledWith(
         `${FETCH_API_BASE_URL}/missions/1/files/`,

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -47,10 +47,7 @@ export function ShowDatasets({
 
   // Creates rows of table
   const rows = data.files.map((file, index) => {
-    const parts = file.split(/[\/\\]/);
-    let type = "?";
-    if (parts.length > 1 && !parts[parts.length - 1].startsWith(parts[0]))
-      type = parts[0];
+    let type = data.types[index];
 
     if (searchFor !== "" && searchFor !== type) return;
 

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "@remix-run/react";
 import { IconClipboard } from "@tabler/icons-react";
 import { useClipboard } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export function ShowDatasets({
   data,
@@ -19,12 +19,38 @@ export function ShowDatasets({
 
   const [searchFor, setSearchFor] = useState<string>("");
 
+  // Deterministic color management without the need of a database :))
+  const typeColorsRef = useRef<Record<string, string>>({});
+  const colorIndexRef = useRef<number>(0);
+
+  const colorList = [
+    "red",
+    "blue",
+    "green",
+    "orange",
+    "purple",
+    "yellow",
+    "cyan",
+    "magenta",
+    "teal",
+    "brown",
+  ];
+
+  const getColorForType = (type: string): string => {
+    if (!typeColorsRef.current[type]) {
+      typeColorsRef.current[type] =
+        colorList[colorIndexRef.current % colorList.length];
+      colorIndexRef.current += 1;
+    }
+    return typeColorsRef.current[type];
+  };
+
   // Creates rows of table
   const rows = data.files.map((file, index) => {
+    const parts = file.split(/[\/\\]/);
     let type = "?";
-    if (file.startsWith("train/") || file.startsWith("train\\")) type = "train";
-    else if (file.startsWith("test/") || file.startsWith("test\\"))
-      type = "test";
+    if (parts.length > 1 && !parts[parts.length - 1].startsWith(parts[0]))
+      type = parts[0];
 
     if (searchFor !== "" && searchFor !== type) return;
 
@@ -73,14 +99,14 @@ export function ShowDatasets({
           </UnstyledButton>
           {(() => {
             let displayFile = file;
-            if (file.startsWith("train/") || file.startsWith("train\\"))
-              displayFile = file.replace("train/", "").replace("train\\", "");
-            else if (file.startsWith("test/") || file.startsWith("test\\"))
-              displayFile = file.replace("test/", "").replace("test\\", "");
+            if (
+              type !== "?" &&
+              (displayFile.startsWith(type + "/") ||
+                displayFile.startsWith(type + "\\"))
+            )
+              displayFile = displayFile.slice(type.length + 1);
 
-            //Remove the redundant folder extension with the same name:
-            displayFile = displayFile.replace(/^[^\\\/]+[\\\/]/, '')
-
+            displayFile = displayFile.replace(/^[^\\\/]+[\\\/]/, "");
             return displayFile;
           })()}
         </Table.Td>
@@ -90,8 +116,7 @@ export function ShowDatasets({
           {(() => {
             let color = "gray";
 
-            if (type === "train") color = "green";
-            else if (type === "test") color = "red";
+            if (type !== "?") color = getColorForType(type);
 
             return (
               <Badge

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -3,7 +3,7 @@ import { LoaderFunctionArgs } from "@remix-run/node";
 import { MetaFunction, redirect, useLoaderData } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { DetailViewData, MissionData, RenderedMission, Tag } from "~/data";
-import { getFormattedDetails } from "~/fetchapi/details";
+import { getFormattedFiles } from "~/fetchapi/details";
 import { getMission } from "~/fetchapi/missions";
 import { getTagsByMission, getTags } from "~/fetchapi/tags";
 import { CreateAppShell } from "~/layout/AppShell";
@@ -88,7 +88,7 @@ function Detail() {
         };
   
         const fetchDetailView = async () => {
-          const detailViewData = await getFormattedDetails(missionId);
+          const detailViewData = await getFormattedFiles(missionId);
           const { commonPath, files } = transformFilePaths(detailViewData.files);
           detailViewData.files = files;
           setBasePath(commonPath);

--- a/frontend/app/routes/details.tsx
+++ b/frontend/app/routes/details.tsx
@@ -2,8 +2,8 @@ import { Skeleton } from "@mantine/core";
 import { LoaderFunctionArgs } from "@remix-run/node";
 import { MetaFunction, redirect, useLoaderData } from "@remix-run/react";
 import { useEffect, useState } from "react";
-import { DetailViewData, MissionData, RenderedMission, Tag } from "~/data";
-import { getFormattedFiles } from "~/fetchapi/details";
+import { convertToDetailViewData, DetailViewData, MissionData, RenderedMission, Tag } from "~/data";
+import { GetFilesByMission } from "~/fetchapi/details";
 import { getMission } from "~/fetchapi/missions";
 import { getTagsByMission, getTags } from "~/fetchapi/tags";
 import { CreateAppShell } from "~/layout/AppShell";
@@ -88,7 +88,7 @@ function Detail() {
         };
   
         const fetchDetailView = async () => {
-          const detailViewData = await getFormattedFiles(missionId);
+          const detailViewData = convertToDetailViewData(await GetFilesByMission(missionId));
           const { commonPath, files } = transformFilePaths(detailViewData.files);
           detailViewData.files = files;
           setBasePath(commonPath);


### PR DESCRIPTION
Hi, this PR resolves issue #251 by dynamically recognizing the parent folder of a file.

For example:
successful_picks/bag_1737641283.2575762/bag_1737641283.2575762_0.mcap

successful_picks would be the type. If no type is present, the fallback type is `?`.
The type is always recognized by checking if the mcap file does not start with the same string as the top level folder.

Currently, the database does not provide colors for the type, so i developed a deterministic method to always choose the same colors, it works like this:
Given is a color map, a color index and a dictionary mapping type name to color:
The first encountered type becomes the first color in the list, the next the second, and so on. In case of an overflow, it begins in the front.

![image](https://github.com/user-attachments/assets/e3828624-be72-42bb-88b2-fedd283c2127)
In the image you see the current color list, that train appears two times with the same color as expected and after a few types, red has to appear again.

![image](https://github.com/user-attachments/assets/e1b6b871-82b2-4ce0-9686-fc4a17e67930)
