### PR TITLE
Added Dataset View Design

### DIFF
--- a/frontend/app/data.tsx
+++ b/frontend/app/data.tsx
@@ -14,6 +14,17 @@ export interface DetailViewData {
   types: string[];
 }
 
+export interface FileData {
+  filePath: string;
+  fileUrl: URL;
+  videoPath: string;
+  videoUrl: URL | null;
+  duration: string;
+  size: string;
+  robot: string;
+  type: string;
+}
+
 //Represents a mission in the backend
 export interface MissionData {
   id: number;
@@ -38,7 +49,7 @@ export interface RenderedMission {
   totalDuration: string;
   totalSize: string;
   robots: string[];
-
+  
   // Inherited from other data structures (details, tags, ...)
   tags: Tag[];
 }
@@ -100,13 +111,3 @@ export function convertToDetailViewData(fileData: FileData[]) : DetailViewData {
   return { files, fileUrls, durations, sizes, robots, types };
 }
 
-export interface FileData {
-  filePath: string;
-  fileUrl: URL;
-  videoPath: string;
-  videoUrl: URL | null;
-  duration: string;
-  size: string;
-  robot: string;
-  type: string;
-}

--- a/frontend/app/pages/dataset/ActionButtons.tsx
+++ b/frontend/app/pages/dataset/ActionButtons.tsx
@@ -18,6 +18,29 @@ export function ActionButtons({
 
   return (
     <Group>
+      {filePath.length > 0 && (
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            clipboard.copy(filePath);
+
+            notifications.clean();
+
+            notifications.show({
+              title: "Copied to clipboard!",
+              message: filePath,
+              color: "orange",
+              radius: "md",
+            });
+          }}
+          variant="light"
+          color="orange"
+          leftSection={<IconClipboard stroke={2} size={14} color="#fd7e14" />}
+        >
+          Copy to clipboard
+        </Button>
+      )}
+
       <Button
         onClick={(e) => {
           e.stopPropagation();
@@ -59,29 +82,6 @@ export function ActionButtons({
       >
         Open in Foxglove
       </Button>
-
-      {filePath.length > 0 && (
-        <Button
-          onClick={(e) => {
-            e.stopPropagation();
-            clipboard.copy(filePath);
-
-            notifications.clean();
-
-            notifications.show({
-              title: "Copied to clipboard!",
-              message: filePath,
-              color: "orange",
-              radius: "md",
-            });
-          }}
-          variant="light"
-          color="orange"
-          leftSection={<IconClipboard stroke={2} size={14} color="#fd7e14" />}
-        >
-          Copy to clipboard
-        </Button>
-      )}
     </Group>
   );
 }

--- a/frontend/app/pages/dataset/ActionButtons.tsx
+++ b/frontend/app/pages/dataset/ActionButtons.tsx
@@ -1,0 +1,87 @@
+import { Button, Group } from "@mantine/core";
+import { useClipboard } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import { IconClipboard, IconDownload } from "@tabler/icons-react";
+
+export function ActionButtons({
+  fileUrl,
+  filePath,
+  displayFile,
+}: {
+  fileUrl: URL | null;
+  filePath: string;
+  displayFile: string;
+}) {
+  if (fileUrl === null) return <div />;
+
+  const clipboard = useClipboard({ timeout: 500 });
+
+  return (
+    <Group>
+      <Button
+        onClick={(e) => {
+          e.stopPropagation();
+
+          const link = document.createElement("a");
+          link.href = fileUrl.toString();
+          link.download = displayFile;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        }}
+        variant="light"
+        color="orange"
+        leftSection={<IconDownload stroke={2} size={14} color="#fd7e14" />}
+      >
+        Download
+      </Button>
+
+      <Button
+        onClick={(e) => {
+          e.stopPropagation();
+
+          const link = document.createElement("a");
+          link.href =
+            "foxglove://open?ds=remote-file&ds.url=" + fileUrl.toString();
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        }}
+        variant="light"
+        color="orange"
+        leftSection={
+          <img
+            src="/fox_glove.svg"
+            alt="Fox Glove Icon"
+            style={{ width: "14px", height: "14px" }}
+          />
+        }
+      >
+        Open in Foxglove
+      </Button>
+
+      {filePath.length > 0 && (
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            clipboard.copy(filePath);
+
+            notifications.clean();
+
+            notifications.show({
+              title: "Copied to clipboard!",
+              message: filePath,
+              color: "orange",
+              radius: "md",
+            });
+          }}
+          variant="light"
+          color="orange"
+          leftSection={<IconClipboard stroke={2} size={14} color="#fd7e14" />}
+        >
+          Copy to clipboard
+        </Button>
+      )}
+    </Group>
+  );
+}

--- a/frontend/app/pages/dataset/DatasetDetailsView.tsx
+++ b/frontend/app/pages/dataset/DatasetDetailsView.tsx
@@ -1,0 +1,32 @@
+import { Text } from "@mantine/core";
+import { VideoComponent } from "./VideoView";
+
+export function DatasetDetails({
+  size,
+  duration,
+  videoUrl,
+}: {
+  size: string;
+  duration: string;
+  videoUrl: URL | null;
+}) {
+  return (
+    <div>
+      <Text size="xl" mb="sm">
+        Details
+      </Text>
+      <Text>
+        <strong>Size:</strong> {size}
+      </Text>
+      <Text>
+        <strong>Duration:</strong> {duration}
+      </Text>
+      <Text>
+        <strong>Video:</strong>
+      </Text>
+      <div style={{ marginTop: "8px" }}>
+        <VideoComponent videoUrl={videoUrl} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/pages/dataset/DatasetView.tsx
+++ b/frontend/app/pages/dataset/DatasetView.tsx
@@ -1,51 +1,47 @@
-import { Text } from "@mantine/core";
-import AbstractPage from "../AbstractPage";
+import { Badge, Group, Grid } from "@mantine/core";
+import { FileData } from "~/data";
+import { ActionButtons } from "./ActionButtons";
+import { DatasetDetails } from "./DatasetDetailsView";
 
-// Interface describing expected properties of DatasetView
-interface DatasetViewProps {
-  file: string | null;
-  fileUrl: URL | null;
-  video: string | null;
-  videoUrl: URL | null;
-  duration: string | null;
-  size: string | null;
-  robot: string | null;
-}
+export function DatasetView(data: FileData) {
+  const displayFile = (data.filePath ?? "").split(/[\\/]/).pop() ?? "";
 
-export function DatasetView(data: DatasetViewProps) {
   return (
-    <AbstractPage headline="Dataset View">
-      {data.file !== null ? (
-        <div>
-          <Text size="lg">File: {data.file}</Text>
-          <Text size="lg">
-            File download: <a href={String(data.fileUrl)}>download</a>{" "}
-            <a
-              href={
-                "foxglove://open?ds=remote-file&ds.url=" + String(data.fileUrl)
-              }
-            >
-              open in Foxglove
-            </a>
-          </Text>
-          <Text size="lg">Duration: {data.duration}</Text>
-          <Text size="lg">Size: {data.size}</Text>
-          <Text size="lg">Robot: {data.robot}</Text>
-          <Text size="lg">Video:</Text>
-          {data.video ? (
-            <iframe
-              width="320"
-              height="320"
-              src={String(data.videoUrl)}
-              allowFullScreen
-            ></iframe>
-          ) : (
-            <Text size="lg">No video available</Text>
-          )}
-        </div>
-      ) : (
-        <Text>No data available</Text>
-      )}
-    </AbstractPage>
+    <div>
+      <Group align="center" style={{ marginBottom: "17px" }}>
+        <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: "normal" }}>
+          {displayFile +
+            (data.robot && data.robot.length > 0 ? " on " + data.robot : "")}
+        </h1>
+
+        <Badge key={data.type} color="orange" variant="light" size="lg">
+          {data.type}
+        </Badge>
+      </Group>
+
+      <Grid gutter="md">
+        {/* Full width on small screens, 9/3 split on md+ screens */}
+        <Grid.Col span={{ base: 12, sm: 12, md: 8 }}>
+          <Grid gutter="md">
+            <Grid.Col span={12}>
+              <ActionButtons
+                filePath={data.filePath ?? ""}
+                fileUrl={data.fileUrl}
+                displayFile={displayFile}
+              />
+            </Grid.Col>
+            <Grid.Col span={12}>Some table</Grid.Col>
+          </Grid>
+        </Grid.Col>
+
+        <Grid.Col span={{ base: 12, sm: 12, md: 4 }}>
+          <DatasetDetails
+            duration={data.duration}
+            size={data.size}
+            videoUrl={data.videoUrl}
+          />
+        </Grid.Col>
+      </Grid>
+    </div>
   );
 }

--- a/frontend/app/pages/dataset/VideoView.tsx
+++ b/frontend/app/pages/dataset/VideoView.tsx
@@ -1,0 +1,27 @@
+import { Text } from "@mantine/core";
+
+export function VideoComponent({ videoUrl }: { videoUrl: URL | null }) {
+  return videoUrl ? (
+    <iframe
+      width="320"
+      height="320"
+      src={String(videoUrl)}
+      allowFullScreen
+    ></iframe>
+  ) : (
+    <div
+      style={{
+        width: "320px",
+        height: "320px",
+        backgroundColor: "#e0e0e0",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Text size="lg" color="gray">
+        Not available
+      </Text>
+    </div>
+  );
+}

--- a/frontend/app/pages/details/InformationView.tsx
+++ b/frontend/app/pages/details/InformationView.tsx
@@ -75,8 +75,8 @@ const EditableField: React.FC<EditableFieldProps> = ({
             />
             <div style={{ display: "flex", justifyContent: "center" }}>
               <Button
-                variant="gradient"
-                gradient={{ from: "yellow", to: "orange", deg: 269 }}
+                variant="light"
+                color="orange"
                 onClick={() => {
                   setMenuOpened(false);
                   onValueChange(fieldValue);

--- a/frontend/app/routes/dataset.tsx
+++ b/frontend/app/routes/dataset.tsx
@@ -1,10 +1,6 @@
 import { Skeleton } from "@mantine/core";
 import { LoaderFunctionArgs } from "@remix-run/node";
-import {
-  MetaFunction,
-  redirect,
-  useLoaderData,
-} from "@remix-run/react";
+import { MetaFunction, redirect, useLoaderData } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { FileData } from "~/data";
 import { getFileData } from "~/fetchapi/details";
@@ -68,17 +64,7 @@ function Dataset() {
   if (error) return <p>Error: {error}</p>;
   if (!fileData) return <p>No data available</p>;
 
-  return (
-    <DatasetView
-      file={fileData.filePath}
-      fileUrl={fileData.fileUrl}
-      video={fileData.videoPath}
-      videoUrl={fileData.videoUrl}
-      duration={fileData.duration}
-      size={fileData.size}
-      robot={fileData.robot}
-    ></DatasetView>
-  );
+  return <DatasetView {...fileData}></DatasetView>;
 }
 
 const App = () => {

--- a/frontend/app/utilities/TagPicker.tsx
+++ b/frontend/app/utilities/TagPicker.tsx
@@ -158,6 +158,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         {/*button to add tag*/}
         <Button
           onClick={handleAddTag}
+          variant="light"
+          color="orange"
           style={{ flex: 0.11, alignSelf: "flex-start" }}
           disabled={!newTagName || !isValidHexColor(selectedColor)}
         >
@@ -258,7 +260,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
                   {/* save button */}
                   <Button
                     size="xs"
-                    color="blue"
+                    variant="light"
+                    color="orange"
                     onClick={() =>
                       handleTagEdit(tag.name, changedTagName, newColor)
                     }
@@ -293,7 +296,8 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         <Popover withArrow withinPortal={false}>
           <Popover.Target>
             <Button
-              color="blue"
+              color="orange"
+              variant="light"
               size="xs"
               style={{ textTransform: "none", width: "48%" }}
               disabled={otherExistingTags.length === 0}
@@ -343,6 +347,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
         {/* delete all tags */}
         <Button
           color="red"
+          variant="light"
           size="xs"
           style={{ textTransform: "none", width: "48%" }}
           disabled={tags.length === 0}


### PR DESCRIPTION
Hi this PR introduces a new dataset design and resolves issue #240. 

Old design:
![image](https://github.com/user-attachments/assets/0d2e6ac4-a7c8-43fe-84d9-a8a73b5e3a90)
New design:
![image](https://github.com/user-attachments/assets/336550a2-a79c-42de-948d-bf6effe8a016)

"OUTDATED" is type of the mcap file. 

There is also already space for the topics table @KageKrito will add. Also added a new way to display the video absence:
![image](https://github.com/user-attachments/assets/2c7cac3a-6063-4f6c-a573-4c8d05eb1838)

This PR includes further design changes, for example, in the dataset view the buttons where changed to a light design:
![image](https://github.com/user-attachments/assets/6d949648-ba08-40b4-8576-451721fb5e0c)

The same for the Tag Picker:
![image](https://github.com/user-attachments/assets/c82b3a02-a5fd-4848-8cf9-e8cad5e6025d)
Just for consistency. 

