### PR TITLE
Added yaml parser to determine message count and frequency

### DIFF
--- a/backend/rosdecoder.py
+++ b/backend/rosdecoder.py
@@ -4,11 +4,45 @@ from rosbags.highlevel import AnyReader
 from rosbags.typesys import Stores, get_typestore
 import numpy as np
 import os
+import yaml
 
-bagpath = Path(r"")
+bagpath = Path(
+    r"C:\Users\felix\uni\teamprojekt\mission_db\backend\media\2024.10.15_picking_even_more_apples\train\bag_1728916632.3249676"
+)
 
 # Create a type store to use if the bag has no message definitions.
 typestore = get_typestore(Stores.ROS2_FOXY)
+
+
+def read_yaml_file(file_path):
+    file_path = str(file_path) + r"\metadata.yaml"
+    with open(file_path, "r") as file:
+        return yaml.safe_load(file)
+
+
+def parse_rosbag_info(file_path):
+    data = read_yaml_file(file_path)
+    duration_ns = (
+        data.get("rosbag2_bagfile_information", {})
+        .get("duration", {})
+        .get("nanoseconds", 0)
+    )
+    topics = data.get("rosbag2_bagfile_information", {}).get(
+        "topics_with_message_count", []
+    )
+
+    topic_msgcount = {}
+    for topic in topics:
+        topic_name = topic.get("topic_metadata", {}).get("name", "Unknown")
+        message_count = topic.get("message_count", 0)
+        topic_msgcount[topic_name] = message_count
+
+    duration_s = duration_ns / 1e9
+    topic_frequency = {}
+    for topic in topic_msgcount:
+        topic_frequency[topic] = round(topic_msgcount[topic] / duration_s, 2)
+    print(duration_s, topic_msgcount, topic_frequency)
+    return duration_s, topic_msgcount, topic_frequency
 
 
 def get_video_topics(path):
@@ -83,7 +117,8 @@ def create_video(data, topic, save_dir=str(bagpath)):
 
 
 if __name__ == "__main__":
-    topics = get_video_topics(bagpath)
-    for topic in topics:
-        data = get_video_data(bagpath, topic)
-        create_video(data[0], data[1])
+    # topics = get_video_topics(bagpath)
+    parse_rosbag_info(bagpath)
+    # for topic in topics:
+    #     data = get_video_data(bagpath, topic)
+    #     create_video(data[0], data[1])


### PR DESCRIPTION
Hello again 👋,

this PR resolves issue #263 and implements functionality to calculate the message count and the frequency of every topic.

## How to test
The best way to test the functionality is by running `parse_rosbag_info(bagpath)` in the script and comparing the calculated values with the ones Foxglove is calculating. Opening the `mcap` files in Foxglove has become much easier since #260.