### PR TITLE
delete folder after test (bugfix)

### DIFF
--- a/backend/cli_commands/RestoreDatabaseCommand.py
+++ b/backend/cli_commands/RestoreDatabaseCommand.py
@@ -39,7 +39,7 @@ def restore_database():
             if f"{mission_name}_metadata.json" not in storage.listdir(folder)[1]:
                 continue
             metadata_file = f"{folder}/{mission_name}_metadata.json"
-            with DefaultStorage().open(metadata_file, "r") as f:
+            with storage.open(metadata_file, "r") as f:
                 metadata = json.load(f)
 
             if not Mission.objects.filter(

--- a/backend/cli_commands/test_restore_database.py
+++ b/backend/cli_commands/test_restore_database.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import logging
 from django.core.files.storage.memory import InMemoryStorage
 
+
 class RestoreDatabaseCommandTests(TestCase):
     def setUp(self):
         RestoreDatabaseCommand.storage = InMemoryStorage()

--- a/backend/cli_commands/test_restore_database.py
+++ b/backend/cli_commands/test_restore_database.py
@@ -1,4 +1,7 @@
 import json
+import os
+import shutil
+from django.conf import settings
 from django.test import TestCase
 from cli_commands.RestoreDatabaseCommand import restore_database
 import cli_commands.RestoreDatabaseCommand as RestoreDatabaseCommand
@@ -37,6 +40,18 @@ class RestoreDatabaseCommandTests(TestCase):
     def tearDown(self):
         # Re-enable logging
         self.logger.disabled = False
+
+        # Clean up the test files and directory
+        file_path = "2024.12.02_test_mission/test_mission_metadata.json"
+        if self.test_storage.exists(file_path):
+            self.test_storage.delete(file_path)
+        
+        # Delete the mission directory
+        dir_path = os.path.join(settings.MEDIA_ROOT, "2024.12.02_test_mission")
+        if os.path.exists(dir_path):
+            shutil.rmtree(dir_path)
+
+        
 
     def test_restore_database(self):
         # Verify mission details before restoration

--- a/backend/cli_commands/test_restore_database.py
+++ b/backend/cli_commands/test_restore_database.py
@@ -9,11 +9,11 @@ from django.core.files.base import ContentFile
 from restapi.models import Mission, Mission_tags
 from datetime import datetime
 import logging
-
+from django.core.files.storage.memory import InMemoryStorage
 
 class RestoreDatabaseCommandTests(TestCase):
     def setUp(self):
-        RestoreDatabaseCommand.storage = RestoreDatabaseCommand.DefaultStorage()
+        RestoreDatabaseCommand.storage = InMemoryStorage()
         self.test_storage = RestoreDatabaseCommand.storage
         self.test_storage.save(
             "2024.12.02_test_mission/test_mission_metadata.json", ContentFile("")

--- a/backend/cli_commands/test_restore_database.py
+++ b/backend/cli_commands/test_restore_database.py
@@ -42,16 +42,6 @@ class RestoreDatabaseCommandTests(TestCase):
         # Re-enable logging
         self.logger.disabled = False
 
-        # Clean up the test files and directory
-        file_path = "2024.12.02_test_mission/test_mission_metadata.json"
-        if self.test_storage.exists(file_path):
-            self.test_storage.delete(file_path)
-
-        # Delete the mission directory
-        dir_path = os.path.join(settings.MEDIA_ROOT, "2024.12.02_test_mission")
-        if os.path.exists(dir_path):
-            shutil.rmtree(dir_path)
-
     def test_restore_database(self):
         # Verify mission details before restoration
         tags = Mission_tags.objects.filter(mission=self.mission)

--- a/backend/cli_commands/test_restore_database.py
+++ b/backend/cli_commands/test_restore_database.py
@@ -45,13 +45,11 @@ class RestoreDatabaseCommandTests(TestCase):
         file_path = "2024.12.02_test_mission/test_mission_metadata.json"
         if self.test_storage.exists(file_path):
             self.test_storage.delete(file_path)
-        
+
         # Delete the mission directory
         dir_path = os.path.join(settings.MEDIA_ROOT, "2024.12.02_test_mission")
         if os.path.exists(dir_path):
             shutil.rmtree(dir_path)
-
-        
 
     def test_restore_database(self):
         # Verify mission details before restoration

--- a/backend/cli_commands/test_restore_database.py
+++ b/backend/cli_commands/test_restore_database.py
@@ -1,7 +1,4 @@
 import json
-import os
-import shutil
-from django.conf import settings
 from django.test import TestCase
 from cli_commands.RestoreDatabaseCommand import restore_database
 import cli_commands.RestoreDatabaseCommand as RestoreDatabaseCommand


### PR DESCRIPTION
# The Problem

In the tests for the restore_database command there is a test folder created in the directory.
Currently it is not beeing deleted after the test so the test_mission folder stays in the storage.

# The fix
I used InMemoryStorage instead of DefaultStorage