### PR TITLE
Fix video codec

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r <(sed 's/--no-binary.*$//g' requirements.txt)
     - name: Set environment variables
       run: |
         echo "DATABASE_NAME=${{ secrets.DATABASE_NAME }}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# polybot_mission_db
+# Mission Explorer
 
 ## Documentation
 
@@ -18,10 +18,22 @@ cd mission_db
 
 #### Backend Setup
 
+To compile opencv-python with the support for h264 codec some system packages are required:
+
+#### In Ubuntu:
+```bash
+sudo apt install cmake gcc g++ python3-dev libavcodec-dev libavformat-dev libswscale-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libgtk-3-dev x264 libx264-dev
+```
+#### In Windows:
+- install cmake
+
+#### both:
+
 ```sh
 cd backend
 pip install -r requirements.txt 
 ```
+This will install all required python packages and compile `opencv-python` which may take up to 30 minutes.
 
 #### Frontend Setup
 

--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -30,15 +30,19 @@ class AddFolderCommand(Command):
 storage = File.file.field.storage
 
 
-def get_duration(path, storage: Storage = storage):
-    with storage.open(path, "rb") as f:
+def get_duration(path, file_storage: Storage = None):
+    if not file_storage:
+        file_storage = File.file.field.storage
+    with file_storage.open(path, "rb") as f:
         reader = make_reader(f)
         statistics = reader.get_summary().statistics
         return (statistics.message_end_time - statistics.message_start_time) * 10**-9
 
 
-def extract_topics_from_mcap(mcap_path, storage: Storage = storage):
-    with storage.open(mcap_path, "rb") as f:
+def extract_topics_from_mcap(mcap_path, file_storage: Storage = None):
+    if not file_storage:
+        file_storage = File.file.field.storage
+    with file_storage.open(mcap_path, "rb") as f:
         reader = make_reader(f)
         summary = reader.get_summary()
         schema_map = {schema.id: schema.name for schema in summary.schemas.values()}

--- a/backend/cli_commands/AddFolderCommand.py
+++ b/backend/cli_commands/AddFolderCommand.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 from .Command import Command
 from restapi.models import Mission, File
+from django.core.files.storage import Storage
 from mcap.reader import make_reader
 
 
@@ -29,14 +30,14 @@ class AddFolderCommand(Command):
 storage = File.file.field.storage
 
 
-def get_duration(path):
+def get_duration(path, storage: Storage = storage):
     with storage.open(path, "rb") as f:
         reader = make_reader(f)
         statistics = reader.get_summary().statistics
         return (statistics.message_end_time - statistics.message_start_time) * 10**-9
 
 
-def extract_topics_from_mcap(mcap_path):
+def extract_topics_from_mcap(mcap_path, storage: Storage = storage):
     with storage.open(mcap_path, "rb") as f:
         reader = make_reader(f)
         summary = reader.get_summary()

--- a/backend/cli_commands/GenerateVideoCommand.py
+++ b/backend/cli_commands/GenerateVideoCommand.py
@@ -244,7 +244,7 @@ def create_video(data, topic, save_dir):
     # Initialize the video writer
     video = cv2.VideoWriter(
         filename,
-        cv2.VideoWriter_fourcc(*"mp4v"),
+        cv2.VideoWriter_fourcc(*"avc1"),
         30,
         (width, height),
         isColor=channels == 3,

--- a/backend/cli_commands/test_add_folder.py
+++ b/backend/cli_commands/test_add_folder.py
@@ -113,8 +113,9 @@ class AddDetailsTests(TestCase):
         return buffer.getvalue()
 
     def setUp(self):
-        AddFolderCommand.storage = InMemoryStorage()
-        self.test_storage = AddFolderCommand.storage
+        self.test_storage = InMemoryStorage()
+        AddFolderCommand.storage = self.test_storage
+        File.file.field.storage = self.test_storage
 
         # create fake files
         mcap_file = ContentFile(self.create_dummy_mcap())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,7 @@ whitenoise
 djangorestframework-api-key==3.*
 mcap
 numpy
-opencv-python
+opencv-python --no-binary opencv-python
 moviepy
 dj-rest-auth==7.*
 boto3==1.*


### PR DESCRIPTION
The videos where generated with the `mp4v` codec which can't be played in some browsers (for example firefox).\
I changed it to `h264/avc1` codec which is supported.

 To use this it is necessary to install the python package `opencv-python` not from the binary but to compile it. I adjusted the requirements.txt so that `pip` does that but it may be necessary to install some libraries in you OS. I used this [guide](https://rockyshikoku.medium.com/use-h264-codec-with-cv2-videowriter-e00145ded181) and the `Required build dependencies` section in the [official documentation](https://docs.opencv.org/4.x/d2/de6/tutorial_py_setup_in_ubuntu.html) for installation in Ubuntu.

The compilation by pip takes quite some time (github took ~27min)

I suspect in Ubuntu it is only necessary to install the required dependencies in the official documentation and the packages `x264 libx264-dev`.\
It would be great if someone could test this before installing all.

I also changed the fps of the video to the frequency of that topic.  With this all videos of one mcap have the same length.

## How to test
Install libraries in your OS.
run
```python
pip install -r requirements.txt
```
generate some videos with the `generate-videos` command of the CLI and open them in the browser. \
You can see the codec information in VLC under Tools > Codec Information