### PR TITLE
Routing bug

### DIFF
--- a/frontend/app/pages/dataset/TopicTable.tsx
+++ b/frontend/app/pages/dataset/TopicTable.tsx
@@ -43,9 +43,6 @@ const query = search.toLowerCase().trim();
 
 return data.filter((item) =>
   keys(data[0]).some((key) => {
-    if (key === 'id') {
-      return false;
-    }
     const value = item[key];
     if (typeof value === 'number') {
       return value.toString() === query;
@@ -77,10 +74,10 @@ return filterData(
     }
 
     if (payload.reversed) {
-      return b[sortBy].toString().localeCompare(a[sortBy].toString());
+      return (b[sortBy]?.toString() ?? '').localeCompare(a[sortBy]?.toString() ?? '');
     }
 
-    return a[sortBy].toString().localeCompare(b[sortBy].toString());
+    return (a[sortBy]?.toString() ?? '').localeCompare(b[sortBy]?.toString() ?? '');
   }),
   payload.search
 );

--- a/frontend/app/pages/dataset/TopicTable.tsx
+++ b/frontend/app/pages/dataset/TopicTable.tsx
@@ -85,9 +85,12 @@ return filterData(
 
 export function TopicTable({ topics }: { topics: Topic[] }) {
 const [search, setSearch] = useState('');
-const [sortedData, setSortedData] = useState(topics);
-const [sortBy, setSortBy] = useState<keyof Topic | null>(null);
+const [sortBy, setSortBy] = useState<keyof Topic>('name');
 const [reverseSortDirection, setReverseSortDirection] = useState(false);
+const [sortedData, setSortedData] = useState(() =>
+  sortData(topics, { sortBy: 'name', reversed: false, search: '' })
+);
+
 
 const setSorting = (field: keyof Topic) => {
   const reversed = field === sortBy ? !reverseSortDirection : false;

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -83,7 +83,7 @@ export function ShowDatasets({
         key={file}
         onClick={() =>
           navigate(
-            "/dataset?fileName=" + missionPathSplitted.concat(file).join("/")
+            "/dataset?fileName=" + basePath + file,
           )
         }
         // Change color on mouse hover

--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -27,7 +27,6 @@ export function ShowDatasets({
 }) {
   const navigate = useNavigate();
   const clipboard = useClipboard({ timeout: 500 });
-  const missionPathSplitted: string[] = basePath.split("/").slice(-2, -1);
 
   const [searchFor, setSearchFor] = useState<string>("");
 


### PR DESCRIPTION
When there is only one mcap file in a mission and you click on it the route falsely gets set as
`http://localhost:5173/dataset?fileName=bag_1728916594.8984177/bag_1728916594.8984177_0.mcap`
instead of the correct route
`http://localhost:5173/dataset?fileName=2024.10.14_picking_apples/test/bag_1728916594.8984177/bag_1728916594.8984177_0.mcap`
This results in a 404 Error

I fixed it and also used this PR to directly sort the Dataset Table by name to make the first time loading of this table more consistent