### PR TITLE
Added line breaks in the topic table

### DIFF
--- a/frontend/app/pages/dataset/TopicTable.tsx
+++ b/frontend/app/pages/dataset/TopicTable.tsx
@@ -107,10 +107,10 @@ const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 
 const rows = sortedData.map((row) => (
   <Table.Tr key={row.name}>
-    <Table.Td>{row.name}</Table.Td>
-    <Table.Td>{row.type}</Table.Td>
-    <Table.Td>{row.message_count}</Table.Td>
-    <Table.Td>{row.frequency}</Table.Td>
+    <Table.Td style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>{row.name}</Table.Td>
+    <Table.Td style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>{row.type}</Table.Td>
+    <Table.Td style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>{row.message_count}</Table.Td>
+    <Table.Td style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>{row.frequency}</Table.Td>
   </Table.Tr>
 ));
 


### PR DESCRIPTION
Hi,
this PR adds linebreaks in the topic table to prevent situations like this:
![image](https://github.com/user-attachments/assets/423493cf-22b2-4978-8129-9aabac092892)

Result:
![image](https://github.com/user-attachments/assets/55833931-9c0c-4429-aa9e-7308b1da440f)
