### PR TITLE
add placeholder for robot name menu

### DIFF
--- a/frontend/app/pages/details/DatasetTable.tsx
+++ b/frontend/app/pages/details/DatasetTable.tsx
@@ -207,6 +207,7 @@ export function ShowDatasets({
           })()}
         </Table.Td>
         <Table.Td style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+          {/* edit robot name button */}
           <Menu
             opened={robotMenuOpened === index}
             onClose={() => {
@@ -226,7 +227,7 @@ export function ShowDatasets({
             <Menu.Dropdown style={{ padding: "10px" }}>
               <Textarea
                 variant="filled"
-                placeholder={data.robots[index]}
+                placeholder={data.robots[index] == null ? "Add robot name" : data.robots[index]}
                 autosize
                 value={fieldValue}
                 error={fieldValue.length > 65536 ? "Name too long" : ""}


### PR DESCRIPTION
The robot menu was missing a placeholder
![grafik](https://github.com/user-attachments/assets/3d12b579-3e8d-4e7a-8622-656d1bd2f39f)

now there is one
![grafik](https://github.com/user-attachments/assets/fbf137b7-aadc-4a70-b30e-6cda3225625d)
